### PR TITLE
Added support for magic param `_method` just like Rails, Sinatra.

### DIFF
--- a/spec/kemal_handler_spec.cr
+++ b/spec/kemal_handler_spec.cr
@@ -120,4 +120,51 @@ describe "Kemal::Handler" do
     response.status_code.should eq 500
     response.body.includes?("Exception").should eq true
   end
+
+  it "checks for _method param in POST request to simulate PUT" do
+    kemal = Kemal::Handler.new
+    kemal.add_route "PUT", "/", do |env|
+      "Hello World from PUT"
+    end
+    request = HTTP::Request.new(
+      "POST",
+      "/",
+      body: "_method=PUT",
+      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded"}
+    )
+    response = kemal.call(request)
+    response.body.should eq("Hello World from PUT")
+  end
+
+  it "checks for _method param in POST request to simulate PATCH" do
+    kemal = Kemal::Handler.new
+    kemal.add_route "PATCH", "/", do |env|
+      "Hello World from PATCH"
+    end
+    request = HTTP::Request.new(
+      "POST",
+      "/",
+      body: "_method=PATCH",
+      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"}
+    )
+    response = kemal.call(request)
+    response.body.should eq("Hello World from PATCH")
+  end
+
+  it "checks for _method param in POST request to simulate DELETE" do
+    kemal = Kemal::Handler.new
+    kemal.add_route "DELETE", "/", do |env|
+      "Hello World from DELETE"
+    end
+    json_payload = {"_method": "DELETE"}
+    request = HTTP::Request.new(
+      "POST",
+      "/",
+      body: json_payload.to_json,
+      headers: HTTP::Headers{"Content-Type": "application/json"}
+    )
+    response = kemal.call(request)
+    response.body.should eq("Hello World from DELETE")
+  end
+
 end

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -29,7 +29,7 @@ class Kemal::ParamParser
   end
 
   def parse_body
-    return unless @request.headers["Content-Type"]? == URL_ENCODED_FORM
+    return if (@request.headers["Content-Type"]? =~ /#{URL_ENCODED_FORM}/).nil?
     parse_part(@request.body)
   end
 

--- a/src/kemal/request.cr
+++ b/src/kemal/request.cr
@@ -1,0 +1,4 @@
+# Opening HTTP::Request to add override_method property
+class HTTP::Request
+	property override_method
+end

--- a/src/kemal/route.cr
+++ b/src/kemal/route.cr
@@ -10,7 +10,9 @@ class Kemal::Route
   end
 
   def match?(request)
-    return nil unless request.method == @method
+    check_for_method_override!(request)
+
+    return nil unless request.override_method == @method
     components = request.path.not_nil!.split "/"
     return nil unless components.size == @components.size
     @components.zip(components) do |route_component, req_component|
@@ -19,5 +21,23 @@ class Kemal::Route
       end
     end
     true
+  end
+
+  # checks if request params contain _method param to override request incoming method
+  def check_for_method_override!(request)
+    request.override_method = request.method
+    if request.method == "POST"
+      params = Kemal::ParamParser.new(self, request).parse_request
+      if params.has_key?("_method") && self.override_method_valid?(params["_method"])
+        request.override_method = params["_method"]
+      end
+    end
+  end
+
+  # checks if method contained in _method param is valid one
+  def override_method_valid?(override_method)
+    return false unless override_method.is_a?(String)
+    override_method = override_method.upcase
+    return (override_method == "PUT" || override_method == "PATCH" || override_method == "DELETE")
   end
 end


### PR DESCRIPTION
Following are the changes made in this commit:

- Added support for magic param `_method` just like Rails, Sinatra
etc.. Browsers which don't support `PUT`, `PATCH` and `DELETE` methods
can simulate them by sending `method` param in request body.

- The default Content-Type to parse request body submitted via forms
etc. is `application/x-www-form-urlencoded`. But if we send Ajax
request in Chrome ($.post) then by-default Content-Type is set to
`application/x-www-form-urlencoded; charset utf-8` which was not
getting matched. I changed the code from `==` to match against a
regular expression using `=~`.

- Print name and color of overridden HTTP method via Logger instead of
printing name and color or request's incoming HTTP method.