### PR TITLE
Add render macro to kemal core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ end
 Kemal.config.add_handler CustomHandler.new
 ```
 
+### Views
+
+You can use ERB-like built-in **ECR** views to render files.
+
+```crystal
+get '/:name' do
+  render "views/hello.ecr"
+end
+```
+
+And you should have an `hello.ecr` view. It will have the same context as the method.
+
+```erb
+Hello <%= env.params["name"] %>
+```
+
 ## Static Files
 
 Kemal has built-in support for serving your static files. You need to put your static files under your ```/public``` directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Kemal means *Mature, grown up* in Turkish.
 ## How to start?
 
  - [Getting Started Tutorial](./tutorial.md)
- - [Using Dynamic Templates (Not Supported Yet)](./templates.md)
+ - [Using Dynamic Views](./views.md)
  - [Parsing HTTP requests and Form Data](./http-requests.md)
  - [Uploading Files](./upload.md)
  - [Serving Static Files](./statics.md)

--- a/docs/views.md
+++ b/docs/views.md
@@ -1,0 +1,28 @@
+# Views
+
+You can use ECR to build views. Kemal serves a `render` macro to use built-in `ECR`
+library.
+
+## Writing Views
+
+The ECR is actually ERB.
+
+```
+src/
+  views/
+    hello.ecr
+```
+
+Write `hello.ecr`
+```erb
+Hello <%= your_name %>
+```
+
+## Embedding View File
+
+```crystal
+get '/' do |env|
+  your_name = "Kemal"
+  render "views/hello.ecr"
+end
+```

--- a/spec/asset/hello.ecr
+++ b/spec/asset/hello.ecr
@@ -1,0 +1,1 @@
+Hello <%= env.params["name"] %>

--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -1,0 +1,13 @@
+require "./spec_helper"
+
+describe "Views" do
+  it "renders file" do
+    kemal = Kemal::Handler.new
+    kemal.add_route "GET", "/view/:name" do |env|
+      render "spec/asset/hello.ecr"
+    end
+    request = HTTP::Request.new("GET", "/view/world")
+    response = kemal.call(request)
+    response.body.should contain("Hello world")
+  end
+end

--- a/src/kemal/view.cr
+++ b/src/kemal/view.cr
@@ -1,0 +1,14 @@
+# Kemal render uses built-in ECR to render methods.
+
+## Usage
+# get '/' do
+#   render 'hello.ecr'
+# end
+
+require "ecr/macros"
+
+macro render(filename)
+  String.build do |__view__|
+    embed_ecr {{filename}}, "__view__"
+  end
+end


### PR DESCRIPTION
To have dynamic rendering mechanism, I created a shortcut to the ECR parser. It actually binds built-in ECR parser to the Kemal as a macro.

DONE
 - [x] Add file parsing.
```crystal
    get "/:name" do |env|
      render "hello.html"
    end
```
TODO
 - [ ] Add string parsing. (It can be handled if the file exists and the string looks like a file path, if not it's a template to parse. Or I can implement a `render_string` macro)
```crystal
    get "/:name" do |env|
      render "hello <%= env.params["name"] %>"
    end
```