### PR TITLE
Removed env from redirect and changed redirect from method to macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,10 @@ Just like other things in `kemal`, browser redirection is super simple as well. 
   # Redirect browser
   get "/logout" do |env|
 	# important stuff like clearing session etc.
-	env.redirect "/login" # redirect to /login page
+	redirect "/login" # redirect to /login page
   end
 ```
+_Make sure to receive `env` as param in defined route's block or you might end-up having compile-time errors._
 
 ## Middlewares
 

--- a/spec/kemal_handler_spec.cr
+++ b/spec/kemal_handler_spec.cr
@@ -187,7 +187,7 @@ describe "Kemal::Handler" do
   it "redirects user to provided url" do
     kemal = Kemal::Handler.new
     kemal.add_route "GET", "/" do |env|
-      env.redirect("/login")
+      redirect "/login"
     end
     request = HTTP::Request.new("GET", "/")
     response = kemal.call(request)

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -9,6 +9,9 @@ at_exit do
     opts.on("-e ", "--environment ", "environment") do |env|
       Kemal.config.env = env
     end
+    opts.on("-w VALUE", "--workers", "workers") do |workers|
+      Kemal.config.workers = workers.to_i
+    end
   end
 
   config = Kemal.config
@@ -23,7 +26,6 @@ at_exit do
 
   Signal::INT.trap {
     logger.write "Kemal is going to take a rest!\n"
-    logger.write "#{Time.now} - Bye Bye!\n\n"
     logger.handler.close
     server.close
     exit
@@ -37,5 +39,11 @@ at_exit do
     File.read(file_path)
   end
 
-  server.listen
+  workers = Kemal.config.workers
+  if workers > 1
+    logger.write "Kemal is starting with #{workers} workers!"
+    server.listen_fork workers: workers
+  else
+    server.listen
+  end
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -5,10 +5,12 @@ module Kemal
     property ssl
     property port
     property env
+    property workers
 
     def initialize
       @port = 3000
       @env = "development" unless @env
+      @workers = 1
     end
 
     def scheme

--- a/src/kemal/context.cr
+++ b/src/kemal/context.cr
@@ -22,11 +22,6 @@ class Kemal::Context
     @response.content_type
   end
 
-  def redirect(url)
-    @response.headers.add "Location", url
-    @response.status_code = 301
-  end
-
   delegate headers, @request
   delegate status_code, @response
   delegate :"status_code=", @response

--- a/src/kemal/macros.cr
+++ b/src/kemal/macros.cr
@@ -1,0 +1,4 @@
+macro redirect(url)
+  env.response.headers.add "Location", {{url}}
+  env.response.status_code = 301
+end

--- a/src/kemal/route.cr
+++ b/src/kemal/route.cr
@@ -11,7 +11,6 @@ class Kemal::Route
 
   def match?(request)
     check_for_method_override!(request)
-
     return nil unless request.override_method == @method
     components = request.path.not_nil!.split "/"
     return nil unless components.size == @components.size

--- a/src/kemal/view.cr
+++ b/src/kemal/view.cr
@@ -1,6 +1,6 @@
 # Kemal render uses built-in ECR to render methods.
 
-## Usage
+# # Usage
 # get '/' do
 #   render 'hello.ecr'
 # end


### PR DESCRIPTION
Removed `env.redirect` in-favor of `redirect` in-order to make Kemal's
API look more like Sinatra.

Thanks @sdogruyol and @f for introducing me to macros :-).