### PR TITLE
Make compatyble with crystal 0.10.0

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -31,7 +31,7 @@ at_exit do
   # This route serves the built-in images for not_found and exceptions.
   get "/__kemal__/:image" do |env|
     image = env.params["image"]
-    file_path = File.expand_path("libs/kemal/images/#{image}", Dir.working_directory)
+    file_path = File.expand_path("libs/kemal/images/#{image}", Dir.current)
     env.add_header "Content-Type", "application/octet-stream"
     File.read(file_path)
   end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -34,10 +34,10 @@ module Kemal
     # config.yml
     # public_folder = "root/to/folder"
     def read_file
-      path = File.expand_path("config.yml", Dir.working_directory)
+      path = File.expand_path("config.yml", Dir.current)
       if File.exists?(path)
         data = YAML.load(File.read(path)) as Hash
-        public_folder = File.expand_path("./#{data["public_folder"]}", Dir.working_directory)
+        public_folder = File.expand_path("./#{data["public_folder"]}", Dir.current)
         @public_folder = public_folder
       end
     end

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -42,7 +42,7 @@ class Kemal::ParamParser
 
     body = @request.body as String
 
-    case json = JSON.parse(body)
+    case json = JSON.parse(body).raw
     when Hash
       json.each do |k, v|
         @params[k as String] = v as AllParamTypes


### PR DESCRIPTION
Hi! because I was testing kemal in crystal 0.10.0, this PR changes `Dir.working_directory` to `Dir.current`
This is a breaking change.

https://github.com/manastech/crystal/releases/tag/0.10.0