### PR TITLE
docs: string require double quotes

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,7 +44,7 @@ Installing kemal (master)
 Open `your_app/src/your_app.cr` and require `kemal` to use Kemal.
 
 ```ruby
-require 'kemal'
+require "kemal"
 ```
 
 ## 4. Hack your project


### PR DESCRIPTION
Otherwise the following error will be shown:

`Syntax error in ... unterminated char literal, use double quotes for strings`

Tested with crystal --version
Crystal 0.10.0 (Wed Dec 23 21:19:16 UTC 2015)

This error is corrected in the example below showing the complete file.