### PR TITLE
Radix-tree already has url param parsing with state-machine implementation which is faster than regex parsing. We don't need regex parsing anymore.

### DIFF
--- a/src/kemal/handler.cr
+++ b/src/kemal/handler.cr
@@ -30,16 +30,15 @@ class Kemal::Handler < HTTP::Handler
     lookup = @tree.find radix_path(context.request.override_method as String, context.request.path)
     if lookup.found?
       route = lookup.payload as Route
-      if route.match?(context.request)
-        begin
-          context.response.content_type = "text/html"
-          body = route.handler.call(context).to_s
-          context.response.print body
-          return context
-        rescue ex
-          Kemal::Logger::INSTANCE.write "Exception: #{ex.to_s}\n"
-          return render_500(context, ex.to_s)
-        end
+      context.request.url_params = lookup.params
+      begin
+        context.response.content_type = "text/html"
+        body = route.handler.call(context).to_s
+        context.response.print body
+        return context
+      rescue ex
+        Kemal::Logger::INSTANCE.write "Exception: #{ex.to_s}\n"
+        return render_500(context, ex.to_s)
       end
     end
     # Render 404 unless a route matches

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -35,14 +35,11 @@ class Kemal::ParamParser
     parse_part(@request.query)
   end
 
-  # Ditto: This needs memoization without the huge AllParamTypes union :|
   def parse_url_params
-    if @request.url_params
-      url_params = @request.url_params.not_nil!
-      name_table = url_params.regex.name_table
-      url_params.size.times do |i|
-        name = (name_table.fetch(i + 1) { i + 1 }) as String
-        @params[name] = url_params[i + 1]
+    params = @request.url_params
+    if params
+      params.not_nil!.each do |key, value|
+        @params[key] = value
       end
     end
   end

--- a/src/kemal/route.cr
+++ b/src/kemal/route.cr
@@ -6,17 +6,6 @@ class Kemal::Route
   getter method
 
   def initialize(@method, @path, &@handler : HTTP::Server::Context -> _)
-    @compiled_regex = pattern_to_regex(@path)
-  end
-
-  def match?(request)
-    self.class.check_for_method_override!(request)
-    return nil unless request.override_method == @method
-    return true if request.path.not_nil!.includes?(':') && request.path.not_nil! == @path
-    request.path.not_nil!.match(@compiled_regex) do |url_params|
-      request.url_params = url_params
-      return true
-    end
   end
 
   # Checks if request params contain _method param to override request incoming method
@@ -35,12 +24,5 @@ class Kemal::Route
     return false unless override_method.is_a?(String)
     override_method = override_method.upcase
     return (override_method == "PUT" || override_method == "PATCH" || override_method == "DELETE")
-  end
-
-  private def pattern_to_regex(pattern)
-    pattern = pattern.gsub(/\:(?<param>\w+)/) do |_, match|
-      "(?<#{match["param"]}>.*)"
-    end
-    Regex.new "^#{pattern}/?$"
   end
 end


### PR DESCRIPTION
It's a total performance boost:

**Before:**
```
Requests/sec:  77267.30
Latency: 522.23us
```

**After:**
```
Requests/sec:  84340.61
Latency: 474.51us
```

🚀🚀🚀