### PR TITLE
Use 302 to redirect instead of 301

### DIFF
--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -204,7 +204,7 @@ describe "Kemal::RouteHandler" do
     request = HTTP::Request.new("GET", "/")
     io_with_context = create_request_and_return_io(kemal, request)
     client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
-    client_response.status_code.should eq(301)
+    client_response.status_code.should eq(302)
     client_response.headers.has_key?("Location").should eq(true)
   end
 end

--- a/src/kemal/context.cr
+++ b/src/kemal/context.cr
@@ -8,9 +8,9 @@ class HTTP::Server
       Kemal::ParamParser.new(@route, @request).parse
     end
 
-    def redirect(url)
+    def redirect(url, status_code = 302)
       @response.headers.add "Location", url
-      @response.status_code = 301
+      @response.status_code = status_code
     end
   end
 end


### PR DESCRIPTION
`301` means "Moved Permanently", so browser caches this redirect, it is used when changing server URL.
`302` means "Found", it is used generally (e.g. redirect top page after login).

Each of `301`, `302`, `303` and `307` means redict, but they are different. We could choice those status in case.