### PR TITLE
Fix undefined variable env error in example code.

### DIFF
--- a/_docs/views.md
+++ b/_docs/views.md
@@ -6,7 +6,7 @@ title: Using Dynamic Views
 You can use ERB-like built-in **ECR** views to render files.
 
 ```ruby
-get '/:name' do
+get '/:name' do |env|
   name = env.params["name"]
   render "views/hello.ecr"
 end


### PR DESCRIPTION
Add missing ```|env|``` to the get-loop.