### PR TITLE
fixed small redundancy.

### DIFF
--- a/src/kemal/common_error_handler.cr
+++ b/src/kemal/common_error_handler.cr
@@ -5,10 +5,10 @@ class Kemal::CommonErrorHandler < HTTP::Handler
     begin
       call_next context
     rescue ex : Kemal::Exceptions::RouteNotFound
-      Kemal.config.logger.write("Exception: #{ex.to_s}: #{ex.message}\n")
+      Kemal.config.logger.write("Exception: #{ex.to_s}\n")
       return render_404(context)
     rescue ex
-      Kemal.config.logger.write("Exception: #{ex.to_s}: #{ex.message}\n")
+      Kemal.config.logger.write("Exception: #{ex.to_s}\n")
       return render_500(context, ex.to_s)
     end
   end


### PR DESCRIPTION
Sorry I made a small mistake in the previous PR.

I didn't realize `to_s` also serialized the `message`, before this it would print like:

`Exception: Requested path: 'GET:/a' was not found.: Requested path: 'GET:/a' was not found.`

instead of

`Exception: Requested path: 'GET:/a' was not found.`