### PR TITLE
Abstract template engines with Kilt

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,8 @@ version: 0.9.0
 dependencies:
   radix:
     github: luislavena/radix
+  kilt:
+    github: jeromegn/kilt
 
 author:
   - Serdar Dogruyol <dogruyolserdar@gmail.com>

--- a/src/kemal/helpers.cr
+++ b/src/kemal/helpers.cr
@@ -1,4 +1,4 @@
-require "ecr/macros"
+require "kilt"
 
 # Uses built-in ECR to render views.
 # # Usage
@@ -7,7 +7,7 @@ require "ecr/macros"
 # end
 macro render(filename)
   __view__ = String::Builder.new
-  embed_ecr({{filename}}, "__view__")
+  Kilt.embed({{filename}}, "__view__")
   __view__.to_s
 end
 


### PR DESCRIPTION
This will allow people to use other template languages (supported by Kilt) without creating different macros.

For instance, if one wanted to use Slang, they'd have to do something like:

```crystal
macro render_slang(filename)
  __view__ = String::Builder.new
  embed_slang({{filename}}, "__view__")
  __view__.to_s
end
```

and then probably write an equivalent one for rendering with a layout.

With this change, no extra code is necessary except for `require "slang"` somewhere.

I know adding dependencies is not something to take lightly, but I think, given the lightweight-ness of Kilt and the minimal changes required to make it work, it's worth considering