### PR TITLE
Make having StaticFileHandler optional

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -4,9 +4,7 @@ require "./kemal/middleware/*"
 at_exit do
   Kemal::CLI.new
   config = Kemal.config
-  config.setup_logging
-  config.setup_error_handler
-  config.add_handler Kemal::StaticFileHandler.new(config.public_folder)
+  config.setup
   config.add_handler Kemal::RouteHandler::INSTANCE
 
   server = HTTP::Server.new(config.host_binding.not_nil!.to_slice, config.port, config.handlers)
@@ -30,7 +28,7 @@ at_exit do
       end
     end
   end
-  
+
   config.logger.write "[#{config.env}] Kemal is ready to lead at #{config.scheme}://#{config.host_binding}:#{config.port}\n"
   server.listen
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -2,12 +2,13 @@ module Kemal
   class Config
     INSTANCE = Config.new
     HANDLERS = [] of HTTP::Handler
-    property host_binding, ssl, port, env, public_folder, logging, always_rescue, error_handler
+    property host_binding, ssl, port, env, public_folder, logging, always_rescue, error_handler, serve_static
 
     def initialize
-      @host_binding = "0.0.0.0" unless @host_binding
+      @host_binding = "0.0.0.0"
       @port = 3000
-      @env = "development" unless @env
+      @env = "development"
+      @serve_static = true
       @public_folder = "./public"
       @logging = true
       @logger = nil
@@ -39,6 +40,12 @@ module Kemal
       HANDLERS << handler
     end
 
+    def setup
+      setup_logging
+      setup_error_handler
+      setup_public_folder
+    end
+
     def setup_logging
       if @logging
         @logger ||= Kemal::CommonLogHandler.new(@env)
@@ -49,11 +56,15 @@ module Kemal
       end
     end
 
-    def setup_error_handler
+    private def setup_error_handler
       if @always_rescue
         @error_handler ||= Kemal::CommonErrorHandler::INSTANCE
         HANDLERS << @error_handler.not_nil!
       end
+    end
+
+    private def setup_public_folder
+      HANDLERS << Kemal::StaticFileHandler.new(@public_folder) if @serve_static
     end
   end
 

--- a/src/kemal/helpers.cr
+++ b/src/kemal/helpers.cr
@@ -46,3 +46,7 @@ def logger(logger)
   Kemal.config.logger = logger
   Kemal.config.add_handler logger
 end
+
+def serve_static(status)
+  Kemal.config.serve_static = status
+end


### PR DESCRIPTION
Hello

Since I plan to only use Kemal for a JSON API I tried to see what would happen if I removed the `StaticFileHandler` (because if there was no overhead there would be no point making it optional).

Here are the results:

With the `StaticFileHandler`:
```
➜  kemal-api git:(master) ✗ crystal build --release src/kemal-api.cr && ./kemal-api
[development] Kemal is ready to lead at http://0.0.0.0:3000
2016-02-15 07:45:01 +0100 | 200 | GET /lol/a - 1.06ms
2016-02-15 07:45:06 +0100 | 200 | GET /lol/a - 41µs
2016-02-15 07:45:14 +0100 | 200 | GET /lol/a - 44µs
2016-02-15 07:45:17 +0100 | 200 | GET /lol/a - 70µs
2016-02-15 07:45:20 +0100 | 200 | GET /lol/a - 63µs
2016-02-15 07:45:22 +0100 | 200 | GET /lol/a - 70µs
2016-02-15 07:45:24 +0100 | 200 | GET /lol/a - 49µs
```

That's really fast and great but as you'll see it still gets significantly faster when removing the `StaticFileHandler`:
```
➜  kemal-api git:(master) ✗ crystal build --release src/kemal-api.cr && ./kemal-api
[development] Kemal is ready to lead at http://0.0.0.0:3000
2016-02-15 07:50:15 +0100 | 200 | GET /lol/a - 673µs
2016-02-15 07:50:19 +0100 | 200 | GET /lol/a - 15µs
2016-02-15 07:50:20 +0100 | 200 | GET /lol/a - 17µs
2016-02-15 07:50:21 +0100 | 200 | GET /lol/a - 22µs
2016-02-15 07:50:22 +0100 | 200 | GET /lol/a - 18µs
2016-02-15 07:50:23 +0100 | 200 | GET /lol/a - 14µs
2016-02-15 07:50:23 +0100 | 200 | GET /lol/a - 25µs
2016-02-15 07:50:24 +0100 | 200 | GET /lol/a - 18µs
2016-02-15 07:50:25 +0100 | 200 | GET /lol/a - 30µs
```

So I made a very small change to add the `StaticFileHandler` only if `@public_folder` is not `Nil` that way I can disable it since I don't want it simply  by setting the `@public_folder`.
It keeps the same behavior as before, by default it will serve `./public`.

What do you think ?

PS: I couldn't make `setup_logging` private because it's called in `spec_helper.cr`