### PR TITLE
Added verb in path for filters

### DIFF
--- a/spec/middleware/filters_spec.cr
+++ b/spec/middleware/filters_spec.cr
@@ -6,7 +6,7 @@ describe "Kemal::Middleware::Filters" do
     test_filter.modified = "false"
 
     filter = Kemal::Middleware::Filter.new
-    filter.add :before, "/greetings", {} of Symbol => String { test_filter.modified = "true" }
+    filter.add("GET", "/greetings", :before) { test_filter.modified = "true" }
 
     kemal = Kemal::RouteHandler.new
     kemal.add_route "GET", "/greetings" { test_filter.modified }

--- a/spec/middleware/filters_spec.cr
+++ b/spec/middleware/filters_spec.cr
@@ -18,6 +18,37 @@ describe "Kemal::Middleware::Filters" do
     client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
     client_response.body.should eq("true")
   end
+
+  it "executes code before GET home request but not POST home request" do
+    test_filter = FilterTest.new
+    test_filter.modified = "false"
+    test_post_filter = FilterTest.new
+    test_post_filter.modified = "false"
+
+    filter = Kemal::Middleware::Filter.new
+    filter.add("GET", "/greetings", :before) { test_filter.modified = "true" }
+    filter.add("POST", "/greetings", :before) { test_filter.modified = "true" }
+
+    kemal = Kemal::RouteHandler.new
+    kemal.add_route "GET", "/greetings" { test_filter.modified }
+    kemal.add_route "POST", "/greetings" { test_post_filter.modified }
+
+    test_filter.modified.should eq("false")
+    test_post_filter.modified.should eq("false")
+
+    request = HTTP::Request.new("GET", "/greetings")
+    create_request_and_return_io(filter, request)
+    io_with_context = create_request_and_return_io(kemal, request)
+    client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
+    client_response.body.should eq("true")
+
+    request = HTTP::Request.new("POST", "/greetings")
+    create_request_and_return_io(filter, request)
+    io_with_context = create_request_and_return_io(kemal, request)
+    client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
+    client_response.body.should eq("false")
+  end
+
 end
 
 class FilterTest

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -12,7 +12,7 @@ end
 
 {% for type in ["before", "after"]%}
   {% for method in HTTP_METHODS %}
-    def {{type.id}}_{{method.id}}(path, &block : HTTP::Server::Context -> _)
+    def {{type.id}}_{{method.id}}(path = "*", &block : HTTP::Server::Context -> _)
      {{type.id}}({{method}}.upcase, path, &block)
     end
   {% end %}

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -9,3 +9,11 @@ HTTP_METHODS = %w(get post put patch delete)
 def ws(path, &block : HTTP::WebSocket -> _)
   Kemal::WebSocketHandler.new path, &block
 end
+
+{% for type in ["before", "after"]%}
+  {% for method in HTTP_METHODS %}
+    def {{type.id}}_{{method.id}}(path, &block : HTTP::Server::Context -> _)
+     {{type.id}}({{method}}.upcase, path, &block)
+    end
+  {% end %}
+{% end %}

--- a/src/kemal/middleware/filters.cr
+++ b/src/kemal/middleware/filters.cr
@@ -32,7 +32,7 @@ module Kemal::Middleware
     end
 
     private def radix_path(verb, path, type : Symbol)
-      "#{verb}/#{path}#{type}"
+      "#{type}/#{verb}/#{path}"
     end
 
     class BeforeFilterAlreadyDefinedException < Exception

--- a/src/kemal/middleware/filters.cr
+++ b/src/kemal/middleware/filters.cr
@@ -6,8 +6,8 @@ module Kemal::Middleware
       @tree = Radix::Tree.new
     end
 
-    def add(type, path, options, &block : HTTP::Server::Context -> _)
-      node = radix_path type, path
+    def add(verb, path, type, &block : HTTP::Server::Context -> _)
+      node = radix_path(verb, path, type)
       @tree.add node, Block.new &block
     end
 
@@ -17,32 +17,33 @@ module Kemal::Middleware
       process_filter(context, :after)
     end
 
-    def filter_for_path_type_defined?(path, type)
-      lookup = @tree.find radix_path(type, path)
+    def filter_for_path_type_defined?(verb, path, type)
+      lookup = @tree.find radix_path(verb, path, type)
       lookup.found? && lookup.payload.is_a? Block
     end
 
     private def process_filter(context, type)
-      lookup = @tree.find radix_path(type, context.request.path)
+      Kemal::Route.check_for_method_override!(context.request)
+      lookup = @tree.find radix_path(context.request.override_method, context.request.path, type)
       if lookup.found? && lookup.payload.is_a? Block
         block = lookup.payload as Block
         block.block.call(context)
       end
     end
 
-    private def radix_path(type : Symbol, path)
-      "/#{type}#{path}"
+    private def radix_path(verb, path, type : Symbol)
+      "#{verb}/#{path}#{type}"
     end
 
     class BeforeFilterAlreadyDefinedException < Exception
-      def initialize(path)
-        super "A before-filter is already defined for path: '#{path}'."
+      def initialize(verb, path)
+        super "A before-filter is already defined for path: '#{verb}:#{path}'."
       end
     end
 
     class AfterFilterAlreadyDefinedException < Exception
-      def initialize(path)
-        super "An after-filter is already defined for path: '#{path}'."
+      def initialize(verb, path)
+        super "An after-filter is already defined for path: '#{verb}:#{path}'."
       end
     end
   end
@@ -63,14 +64,14 @@ def add_filters
   filter
 end
 
-def before(path = "*", options = {} of Symbol => String, &block : HTTP::Server::Context -> _)
+def before(verb, path = "*", &block : HTTP::Server::Context -> _)
   filter = (Kemal.config.handlers.find { |handler| handler.is_a? Kemal::Middleware::Filter } || add_filters) as Kemal::Middleware::Filter
-  raise Kemal::Middleware::Filter::BeforeFilterAlreadyDefinedException.new(path) if filter.filter_for_path_type_defined?(path, :before)
-  filter.add :before, path, options, &block
+  raise Kemal::Middleware::Filter::BeforeFilterAlreadyDefinedException.new(verb, path) if filter.filter_for_path_type_defined?(verb, path, :before)
+  filter.add verb, path, :before, &block
 end
 
-def after(path = "*", options = {} of Symbol => String, &block : HTTP::Server::Context -> _)
+def after(verb, path = "*", &block : HTTP::Server::Context -> _)
   filter = (Kemal.config.handlers.find { |handler| handler.is_a? Kemal::Middleware::Filter } || add_filters) as Kemal::Middleware::Filter
-  raise Kemal::Middleware::Filter::AfterFilterAlreadyDefinedException.new(path) if filter.filter_for_path_type_defined?(path, :after)
-  filter.add :after, path, options, &block
+  raise Kemal::Middleware::Filter::AfterFilterAlreadyDefinedException.new(verb, path) if filter.filter_for_path_type_defined?(verb, path, :after)
+  filter.add verb, path, :after, &block
 end


### PR DESCRIPTION
Hi...

I'm sorry, I know I'm bothering you every day and after the last one I promised myself I wouldn't annoy you anymore with these small changes but then I realized that the Filter implementation was still not right.

I didn't realize it at first but the way it was previously done `before` and `after` filters would be called for all the methods which matched one path, for example:

    before "/hello" do
      puts "before hello"
    end

Would be called before:
 - GET /hello
 - POST /hello
 - PUT /hello
 - DELETE /hello
 - etc...

I don't think this was intended, but if I'm mistaken just close it. Again the changes are very small but I added the `verb` for each `before` and `after`, now you would define it like this:

    before "GET", "/hello" do
      puts "before hello"
    end

PS: I know you must be busy, I'm sorry.
PPS: I just realized this could be done with macros, and instead of `before "GET", "/hello"` we would have something like `before_get "/hello"`