### PR TITLE
use new Kilt >= 0.2 syntax, add mention in readme for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ These results were achieved with ```wrk``` on a Macbook Pro Late 2013. (**2Ghz i
 - Middlewares
 - Built-in JSON support
 - Built-in static file serving
-- Built-in view templating via ecr
+- Built-in view templating via ECR (using [Kilt](https://github.com/jeromegn/kilt))
 
 # Documentation
 

--- a/src/kemal/helpers.cr
+++ b/src/kemal/helpers.cr
@@ -5,15 +5,14 @@ require "kilt"
 # get '/' do
 #   render 'hello.ecr'
 # end
-macro render(filename)
-  __view__ = String::Builder.new
-  Kilt.embed({{filename}}, "__view__")
-  __view__.to_s
-end
 
 macro render(filename, layout)
   content = render {{filename}}
   render {{layout}}
+end
+
+macro render(filename, *args)
+  Kilt.render({{filename}}, {{*args}})
 end
 
 def add_handler(handler)


### PR DESCRIPTION
Since Kilt >= 0.2 (now v0.3.0), there's a simpler `Kilt.render` method to embed to a String directly.

Also, some templating engines take other arguments therefore that's now possible with the args splat.

I've added a mention in the README so that people understand a little better why the kilt dependency.