### PR TITLE
Ability to add many blocks per route filter

### DIFF
--- a/spec/middleware/filters_spec.cr
+++ b/spec/middleware/filters_spec.cr
@@ -143,6 +143,46 @@ describe "Kemal::Middleware::Filters" do
     client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
     client_response.body.should eq("false")
   end
+
+  it "executes 3 differents blocks after all request" do
+    test_filter = FilterTest.new
+    test_filter.modified = "false"
+    test_filter_second = FilterTest.new
+    test_filter_second.modified = "false"
+    test_filter_third = FilterTest.new
+    test_filter_third.modified = "false"
+
+    filter_middleware = Kemal::Middleware::Filter.new
+    filter_middleware._add_route_filter("ALL", "/greetings", :before) { test_filter.modified = test_filter.modified == "true" ? "false" : "true" }
+    filter_middleware._add_route_filter("ALL", "/greetings", :before) { test_filter_second.modified = test_filter_second.modified == "true" ? "false" : "true" }
+    filter_middleware._add_route_filter("ALL", "/greetings", :before) { test_filter_third.modified = test_filter_third.modified == "true" ? "false" : "true" }
+
+    kemal = Kemal::RouteHandler::INSTANCE
+    kemal.add_route "GET", "/greetings" { test_filter.modified }
+    kemal.add_route "POST", "/greetings" { test_filter_second.modified }
+    kemal.add_route "PUT", "/greetings" { test_filter_third.modified }
+
+    test_filter.modified.should eq("false")
+    test_filter_second.modified.should eq("false")
+    test_filter_third.modified.should eq("false")
+    request = HTTP::Request.new("GET", "/greetings")
+    create_request_and_return_io(filter_middleware, request)
+    io_with_context = create_request_and_return_io(kemal, request)
+    client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
+    client_response.body.should eq("true")
+
+    request = HTTP::Request.new("POST", "/greetings")
+    create_request_and_return_io(filter_middleware, request)
+    io_with_context = create_request_and_return_io(kemal, request)
+    client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
+    client_response.body.should eq("false")
+
+    request = HTTP::Request.new("PUT", "/greetings")
+    create_request_and_return_io(filter_middleware, request)
+    io_with_context = create_request_and_return_io(kemal, request)
+    client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
+    client_response.body.should eq("true")
+  end
 end
 
 class FilterTest


### PR DESCRIPTION
@jeromegn pointed out to me in #105 that people might want to call many times `before_x` or `after_x` so I updated the filter, it no longer raises an exception if there's already one filter for this verb/path.
And now calls all the blocks in the order they were defined.

Also I'll make it clear in the docs but these convenience methods should __not__ be used by plugins/addons, instead they should do all their work in their own middleware.

PS: this time I ran `crystal tool format` should look better than the previous PR :smile: 