### PR TITLE
Decoupled urlparams from routehandler.

### DIFF
--- a/src/kemal/context.cr
+++ b/src/kemal/context.cr
@@ -3,6 +3,7 @@
 class HTTP::Server
   class Context
     def params
+      @request.url_params = route_lookup.params
       @params ||= Kemal::ParamParser.new(@request).parse
     end
 

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -18,10 +18,10 @@ class Kemal::ParamParser
   end
 
   def parse_request
-    parse_url_params
     parse_query
     parse_body
     parse_json
+    parse_url_params
     @params
   end
 

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -33,7 +33,6 @@ class Kemal::RouteHandler < HTTP::Handler
   def process_request(context)
     raise Kemal::Exceptions::RouteNotFound.new(context) unless context.route_defined?
     route = context.route_lookup.payload as Route
-    context.request.url_params = context.route_lookup.params
     context.response.print(route.handler.call(context).to_s)
     context
   end


### PR DESCRIPTION
Hi :smile: 

I realized some middlewares will want to have access to the params, and most of them are already available in `context.params` but they wouldn't get the `urlparams` because `request.url_params` was set in the `RouteHandler`.

Now the url_params are lazily set and parsed when `params` is accessed on the context (therefore accessible to all the middlewares).

(This is a 2 lines change).

Also I made the `parse_url_params` last so they don't get overwritten by params in the body.