### PR TITLE
Set positions for errors and logger middleware, added 2 views

### DIFF
--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -49,22 +49,21 @@ module Kemal
     def setup_logging
       if @logging
         @logger ||= Kemal::CommonLogHandler.new(@env)
-        HANDLERS << @logger.not_nil!
+        HANDLERS.insert(0, @logger.not_nil!)
       else
         @logger = Kemal::NullLogHandler.new(@env)
-        HANDLERS << @logger.not_nil!
       end
     end
 
     private def setup_error_handler
       if @always_rescue
         @error_handler ||= Kemal::CommonErrorHandler::INSTANCE
-        HANDLERS << @error_handler.not_nil!
+        HANDLERS.insert(1, @error_handler.not_nil!)
       end
     end
 
     private def setup_public_folder
-      HANDLERS << Kemal::StaticFileHandler.new(@public_folder) if @serve_static
+      HANDLERS.insert(2, Kemal::StaticFileHandler.new(@public_folder)) if @serve_static
     end
   end
 

--- a/src/kemal/view.cr
+++ b/src/kemal/view.cr
@@ -67,3 +67,51 @@ def render_500(context, ex)
   context.response.print template
   context
 end
+
+# Template for 415 Unsupported media type
+def render_415(context, message)
+  template = <<-HTML
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <style type="text/css">
+            body { text-align:center;font-family:helvetica,arial;font-size:22px;
+              color:#888;margin:20px}
+            #c {margin:0 auto;width:500px;text-align:left}
+            </style>
+          </head>
+          <body>
+            <h2>Unsupported media type</h2>
+            <h3>#{message}</h3>
+            <img src="/__kemal__/404.png">
+          </body>
+          </html>
+      HTML
+  context.response.status_code = 415
+  context.response.print template
+  context
+end
+
+# Template for 400 Bad request
+def render_400(context, message)
+  template = <<-HTML
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <style type="text/css">
+            body { text-align:center;font-family:helvetica,arial;font-size:22px;
+              color:#888;margin:20px}
+            #c {margin:0 auto;width:500px;text-align:left}
+            </style>
+          </head>
+          <body>
+            <h2>Bad request</h2>
+            <h3>#{message}</h3>
+            <img src="/__kemal__/404.png">
+          </body>
+          </html>
+      HTML
+  context.response.status_code = 400
+  context.response.print template
+  context
+end


### PR DESCRIPTION
The logger and errors middleware should always be first and second, so that if I have a custom error handler middleware I can make it rescue anything even an exception that would be raised by another middleware. 
Same for the logger, since it logs the time it takes to process a request it makes sense that it's the first called.

Also added 2 views that I needed for parameters validation `render_400` and `render_415`.
