### PR TITLE
add support for cookie-based sessions

### DIFF
--- a/spec/session_cookie_handler_spec.cr
+++ b/spec/session_cookie_handler_spec.cr
@@ -1,0 +1,47 @@
+require "./spec_helper"
+
+describe Kemal::SessionCookieHandler do
+
+  it "raises an ArgumentError if secret is not provided" do
+    request = HTTP::Request.new("GET", "/")
+    io = MemoryIO.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    session = Kemal::SessionCookieHandler::INSTANCE
+    context.session["authorized"] = "true"
+    begin
+      session.call(context)
+    rescue ex : ArgumentError
+      ex.message.should eq "Please provide a Secret. You may generate one using: \ncrystal eval \"require \"secure_random\"; puts SecureRandom.hex(64)\""
+    end
+  end
+
+  it "sets a cookie" do
+    request = HTTP::Request.new("GET", "/")
+    io = MemoryIO.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    session = Kemal::SessionCookieHandler::INSTANCE
+    session.secret = "0c04a88341ec9ffd2794a0d35c9d58109d8fff32dfc48194c2a2a8fc62091190920436d58de598ca9b44dd20e40b1ab431f6dcaa40b13642b69d0edff73d7374"
+    session.call(context)
+    context.response.headers.has_key?("set-cookie").should be_true
+  end
+
+  it "encodes the session data" do
+    request = HTTP::Request.new("GET", "/")
+    io = MemoryIO.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    session = Kemal::SessionCookieHandler::INSTANCE
+    session.secret = "0c04a88341ec9ffd2794a0d35c9d58109d8fff32dfc48194c2a2a8fc62091190920436d58de598ca9b44dd20e40b1ab431f6dcaa40b13642b69d0edff73d7374"
+    context.session["authorized"] = "true"
+    session.call(context)
+    cookie = context.response.headers["set-cookie"]
+    cookie.should eq "kemal.session=d5374f304c4a343e14fca421e4c372c777207337--eyJhdXRob3JpemVkIjoidHJ1ZSJ9%0A; path=/"
+  end
+  
+end
+
+
+

--- a/src/kemal/context.cr
+++ b/src/kemal/context.cr
@@ -7,7 +7,7 @@ class HTTP::Server
       @params ||= Kemal::ParamParser.new(@request).parse
     end
 
-    def redirect(url, status_code = 302)
+   def redirect(url, status_code = 302)
       @response.headers.add "Location", url
       @response.status_code = status_code
     end
@@ -19,5 +19,14 @@ class HTTP::Server
     def route_defined?
       route_lookup.found?
     end
+
+    def clear_session
+      @session = {} of String => String
+    end
+
+    def session
+      @session ||= {} of String => String
+    end
+
   end
 end

--- a/src/kemal/session_cookie_handler.cr
+++ b/src/kemal/session_cookie_handler.cr
@@ -1,0 +1,65 @@
+require "http/cookie"
+require "base64"
+require "json"
+require "openssl/hmac"
+
+module Kemal
+  class SessionCookieHandler < HTTP::Handler
+    property :key, :secret
+
+    INSTANCE = new
+    
+    def initialize
+      @key = "kemal.session"
+      @secret = "change_me"
+    end
+
+    def self.config
+      yield self.instance
+    end
+   
+    def config
+      yield self
+    end
+
+    def call(context)
+      if @secret == "change_me"
+        raise ArgumentError.new(<<-MESSAGE
+        Please provide a Secret. You may generate one using: 
+        crystal eval "require \"secure_random\"; puts SecureRandom.hex(64)"
+        MESSAGE
+        )
+      end
+      
+      cookies = HTTP::Cookies.from_headers(context.request.headers)
+      decode(context.session, cookies[@key].value) if cookies.has_key?(@key)
+      call_next(context)
+      value = encode(context.session)
+      cookies = HTTP::Cookies.from_headers(context.response.headers)
+      cookies << HTTP::Cookie.new(@key, value)
+      cookies.add_response_headers(context.response.headers)
+      context
+    end
+
+    def decode (session, data)
+      sha1, data = data.split("--", 2)
+      if sha1 == OpenSSL::HMAC.hexdigest(:sha1, @secret, data) 
+        json = Base64.decode_string(data)
+        values = JSON.parse(json)
+        values.each do |key, value|
+          session[key.to_s] = value.to_s
+        end
+      end
+    end
+
+    def encode (session)
+      data = Base64.encode(session.to_json)
+      sha1 = OpenSSL::HMAC.hexdigest(:sha1, @secret, data)
+      return "#{sha1}--#{data}"
+    end
+    
+  end
+end
+
+
+


### PR DESCRIPTION
Adds support for sessions.  This is based on the way that Rack's cookie-based session middleware is handled.

The secret is a required parameter that can be setup using: 
`Kemal::SessionCookieHandler::INSTANCE.config { |c| c.secret = "my secret" }`

Currently the session only supports `{} of String => String`.