### PR TITLE
Upgrade ParamParser to make it more convinient.

### DIFF
--- a/spec/param_parser_spec.cr
+++ b/spec/param_parser_spec.cr
@@ -3,19 +3,31 @@ require "./spec_helper"
 describe "ParamParser" do
   it "parses query params" do
     route = Route.new "POST", "/" do |env|
-      hasan = env.params["hasan"]
+      hasan = env.params.query["hasan"]
       "Hello #{hasan}"
     end
     request = HTTP::Request.new("POST", "/?hasan=cemal")
-    params = Kemal::ParamParser.new(request).parse
-    params["hasan"].should eq "cemal"
+    query_params = Kemal::ParamParser.new(request).params.query
+    query_params["hasan"].should eq "cemal"
+  end
+
+  it "parses url params" do
+    kemal = Kemal::RouteHandler::INSTANCE
+    kemal.add_route "POST", "/hello/:hasan" do |env|
+      "hello #{env.params.url["hasan"]}"
+    end
+    request = HTTP::Request.new("POST", "/hello/cemal")
+    # Radix tree MUST be run to parse url params.
+    io_with_context = create_request_and_return_io(kemal, request)
+    url_params = Kemal::ParamParser.new(request).params.url
+    url_params["hasan"].should eq "cemal"
   end
 
   it "parses request body" do
     route = Route.new "POST", "/" do |env|
-      name = env.params["name"]
-      age = env.params["age"]
-      hasan = env.params["hasan"]
+      name = env.params.query["name"]
+      age = env.params.query["age"]
+      hasan = env.params.body["hasan"]
       "Hello #{name} #{hasan} #{age}"
     end
 
@@ -26,8 +38,11 @@ describe "ParamParser" do
       headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded"},
     )
 
-    params = Kemal::ParamParser.new(request).parse
-    params.should eq({"hasan" => "cemal", "name" => "serdar", "age" => "99"})
+    query_params = Kemal::ParamParser.new(request).params.query
+    query_params.should eq({"hasan" => "cemal"})
+
+    body_params = Kemal::ParamParser.new(request).params.body
+    body_params.should eq({"name" => "serdar", "age" => "99"})
   end
 
   context "when content type is application/json" do
@@ -41,8 +56,8 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "application/json"},
       )
 
-      params = Kemal::ParamParser.new(request).parse
-      params.should eq({"name": "Serdar"})
+      json_params = Kemal::ParamParser.new(request).params.json
+      json_params.should eq({"name": "Serdar"})
     end
 
     it "parses request body for array" do
@@ -55,8 +70,8 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "application/json"},
       )
 
-      params = Kemal::ParamParser.new(request).parse
-      params.should eq({"_json": [1]})
+      json_params = Kemal::ParamParser.new(request).params.json
+      json_params.should eq({"_json": [1]})
     end
 
     it "parses request body and query params" do
@@ -69,8 +84,11 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "application/json"},
       )
 
-      params = Kemal::ParamParser.new(request).parse
-      params.should eq({"foo": "bar", "_json": [1]})
+      query_params = Kemal::ParamParser.new(request).params.query
+      query_params.should eq({"foo": "bar"})
+
+      json_params = Kemal::ParamParser.new(request).params.json
+      json_params.should eq({"_json": [1]})
     end
 
     it "handles no request body" do
@@ -82,17 +100,26 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "application/json"},
       )
 
-      params = Kemal::ParamParser.new(request).parse
-      params.should eq({} of String => AllParamTypes)
+      url_params = Kemal::ParamParser.new(request).params.url
+      url_params.should eq({} of String => String)
+
+      query_params = Kemal::ParamParser.new(request).params.query
+      query_params.should eq({} of String => String)
+
+      body_params = Kemal::ParamParser.new(request).params.body
+      body_params.should eq({} of String => String)
+
+      json_params = Kemal::ParamParser.new(request).params.json
+      json_params.should eq({} of String => AllParamTypes)
     end
   end
 
   context "when content type is incorrect" do
     it "does not parse request body" do
       route = Route.new "POST", "/" do |env|
-        name = env.params["name"]
-        age = env.params["age"]
-        hasan = env.params["hasan"]
+        name = env.params.body["name"]
+        age = env.params.body["age"]
+        hasan = env.params.query["hasan"]
         "Hello #{name} #{hasan} #{age}"
       end
 
@@ -103,8 +130,11 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "text/plain"},
       )
 
-      params = Kemal::ParamParser.new(request).parse
-      params.should eq({"hasan" => "cemal"})
+      query_params = Kemal::ParamParser.new(request).params.query
+      query_params.should eq({"hasan" => "cemal"})
+
+      body_params = Kemal::ParamParser.new(request).params.body
+      body_params.should eq({} of String => String)
     end
   end
 end

--- a/spec/param_parser_spec.cr
+++ b/spec/param_parser_spec.cr
@@ -7,7 +7,7 @@ describe "ParamParser" do
       "Hello #{hasan}"
     end
     request = HTTP::Request.new("POST", "/?hasan=cemal")
-    query_params = Kemal::ParamParser.new(request).params.query
+    query_params = Kemal::ParamParser.new(request).query
     query_params["hasan"].should eq "cemal"
   end
 
@@ -19,7 +19,7 @@ describe "ParamParser" do
     request = HTTP::Request.new("POST", "/hello/cemal")
     # Radix tree MUST be run to parse url params.
     io_with_context = create_request_and_return_io(kemal, request)
-    url_params = Kemal::ParamParser.new(request).params.url
+    url_params = Kemal::ParamParser.new(request).url
     url_params["hasan"].should eq "cemal"
   end
 
@@ -38,10 +38,10 @@ describe "ParamParser" do
       headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded"},
     )
 
-    query_params = Kemal::ParamParser.new(request).params.query
+    query_params = Kemal::ParamParser.new(request).query
     query_params.should eq({"hasan" => "cemal"})
 
-    body_params = Kemal::ParamParser.new(request).params.body
+    body_params = Kemal::ParamParser.new(request).body
     body_params.should eq({"name" => "serdar", "age" => "99"})
   end
 
@@ -56,7 +56,7 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "application/json"},
       )
 
-      json_params = Kemal::ParamParser.new(request).params.json
+      json_params = Kemal::ParamParser.new(request).json
       json_params.should eq({"name": "Serdar"})
     end
 
@@ -70,7 +70,7 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "application/json"},
       )
 
-      json_params = Kemal::ParamParser.new(request).params.json
+      json_params = Kemal::ParamParser.new(request).json
       json_params.should eq({"_json": [1]})
     end
 
@@ -84,10 +84,10 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "application/json"},
       )
 
-      query_params = Kemal::ParamParser.new(request).params.query
+      query_params = Kemal::ParamParser.new(request).query
       query_params.should eq({"foo": "bar"})
 
-      json_params = Kemal::ParamParser.new(request).params.json
+      json_params = Kemal::ParamParser.new(request).json
       json_params.should eq({"_json": [1]})
     end
 
@@ -100,16 +100,16 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "application/json"},
       )
 
-      url_params = Kemal::ParamParser.new(request).params.url
+      url_params = Kemal::ParamParser.new(request).url
       url_params.should eq({} of String => String)
 
-      query_params = Kemal::ParamParser.new(request).params.query
+      query_params = Kemal::ParamParser.new(request).query
       query_params.should eq({} of String => String)
 
-      body_params = Kemal::ParamParser.new(request).params.body
+      body_params = Kemal::ParamParser.new(request).body
       body_params.should eq({} of String => String)
 
-      json_params = Kemal::ParamParser.new(request).params.json
+      json_params = Kemal::ParamParser.new(request).json
       json_params.should eq({} of String => AllParamTypes)
     end
   end
@@ -130,10 +130,10 @@ describe "ParamParser" do
         headers: HTTP::Headers{"Content-Type": "text/plain"},
       )
 
-      query_params = Kemal::ParamParser.new(request).params.query
+      query_params = Kemal::ParamParser.new(request).query
       query_params.should eq({"hasan" => "cemal"})
 
-      body_params = Kemal::ParamParser.new(request).params.body
+      body_params = Kemal::ParamParser.new(request).body
       body_params.should eq({} of String => String)
     end
   end

--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -170,8 +170,8 @@ describe "Kemal::RouteHandler" do
     request = HTTP::Request.new(
       "POST",
       "/",
-      body: json_payload.to_json,
-      headers: HTTP::Headers{"Content-Type": "application/json"}
+      body: "_method=DELETE",
+      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"}
     )
     io_with_context = create_request_and_return_io(kemal, request)
     client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)

--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -15,7 +15,7 @@ describe "Kemal::RouteHandler" do
   it "routes request with query string" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "GET", "/" do |env|
-      "hello #{env.params["message"]}"
+      "hello #{env.params.query["message"]}"
     end
     request = HTTP::Request.new("GET", "/?message=world")
     io_with_context = create_request_and_return_io(kemal, request)
@@ -26,7 +26,7 @@ describe "Kemal::RouteHandler" do
   it "routes request with multiple query strings" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "GET", "/" do |env|
-      "hello #{env.params["message"]} time #{env.params["time"]}"
+      "hello #{env.params.query["message"]} time #{env.params.query["time"]}"
     end
     request = HTTP::Request.new("GET", "/?message=world&time=now")
     io_with_context = create_request_and_return_io(kemal, request)
@@ -37,7 +37,7 @@ describe "Kemal::RouteHandler" do
   it "route parameter has more precedence than query string arguments" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "GET", "/:message" do |env|
-      "hello #{env.params["message"]}"
+      "hello #{env.params.url["message"]}"
     end
     request = HTTP::Request.new("GET", "/world?message=coco")
     io_with_context = create_request_and_return_io(kemal, request)
@@ -48,8 +48,8 @@ describe "Kemal::RouteHandler" do
   it "parses simple JSON body" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "POST", "/" do |env|
-      name = env.params["name"]
-      age = env.params["age"]
+      name = env.params.json["name"]
+      age = env.params.json["age"]
       "Hello #{name} Age #{age}"
     end
 
@@ -68,7 +68,7 @@ describe "Kemal::RouteHandler" do
   it "parses JSON with string array" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "POST", "/" do |env|
-      skills = env.params["skills"] as Array
+      skills = env.params.json["skills"] as Array
       "Skills #{skills.each.join(',')}"
     end
 
@@ -87,7 +87,7 @@ describe "Kemal::RouteHandler" do
   it "parses JSON with json object array" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "POST", "/" do |env|
-      skills = env.params["skills"] as Array
+      skills = env.params.json["skills"] as Array
       skills_from_languages = skills.map do |skill|
         skill = skill as Hash
         skill["language"]

--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -8,7 +8,7 @@ describe "Views" do
   it "renders file" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "GET", "/view/:name" do |env|
-      name = env.params["name"]
+      name = env.params.url["name"]
       render "spec/asset/hello.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
@@ -20,7 +20,7 @@ describe "Views" do
   it "renders file with dynamic variables" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "GET", "/view/:name" do |env|
-      name = env.params["name"]
+      name = env.params.url["name"]
       render_with_base_and_layout "hello.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
@@ -32,7 +32,7 @@ describe "Views" do
   it "renders layout" do
     kemal = Kemal::RouteHandler::INSTANCE
     kemal.add_route "GET", "/view/:name" do |env|
-      name = env.params["name"]
+      name = env.params.url["name"]
       render "spec/asset/hello.ecr", "spec/asset/layout.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -18,7 +18,7 @@ at_exit do
 
   # This route serves the built-in images for not_found and exceptions.
   get "/__kemal__/:image" do |env|
-    image = env.params["image"]
+    image = env.params.url["image"]
     file_path = File.expand_path("libs/kemal/images/#{image}", Dir.current)
     if File.exists? file_path
       env.response.headers.add "Content-Type", "application/octet-stream"

--- a/src/kemal/context.cr
+++ b/src/kemal/context.cr
@@ -2,7 +2,6 @@
 # information such as params, content_type e.g
 class HTTP::Server
   class Context
-
     def params
       @request.url_params = route_lookup.params
       @params ||= Kemal::ParamParser.new(@request)

--- a/src/kemal/context.cr
+++ b/src/kemal/context.cr
@@ -5,7 +5,7 @@ class HTTP::Server
 
     def params
       @request.url_params = route_lookup.params
-      @params ||= Kemal::ParamParser.new(@request).params
+      @params ||= Kemal::ParamParser.new(@request)
     end
 
     def redirect(url, status_code = 302)

--- a/src/kemal/context.cr
+++ b/src/kemal/context.cr
@@ -2,9 +2,10 @@
 # information such as params, content_type e.g
 class HTTP::Server
   class Context
+
     def params
       @request.url_params = route_lookup.params
-      @params ||= Kemal::ParamParser.new(@request).parse
+      @params ||= Kemal::ParamParser.new(@request).params
     end
 
     def redirect(url, status_code = 302)

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -18,7 +18,12 @@ class Kemal::ParamParser
 
   {% for method in %w(url query body json) %}
   def {{method.id}}
+    # check memoization
+    return @{{method.id}} if @{{method.id}}_parsed
+
     parse_{{method.id}}
+    # memoize
+    @{{method.id}}_parsed = true
     @{{method.id}}
   end
   {% end %}
@@ -67,6 +72,4 @@ class Kemal::ParamParser
     end
     part_params
   end
-
 end
-

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -23,10 +23,6 @@ class Kemal::ParamParser
     parse_request
   end
 
-  def params
-    @query.merge(@body).merge(@json).merge(@url)
-  end
-
   def parse_request
     parse_query
     parse_body

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -9,26 +9,19 @@ class Kemal::ParamParser
   URL_ENCODED_FORM = "application/x-www-form-urlencoded"
   APPLICATION_JSON = "application/json"
 
-  getter url
-  getter query
-  getter body
-  getter json
-
   def initialize(@request)
     @url = {} of String => String
     @query = {} of String => String
     @body = {} of String => String
     @json = {} of String => AllParamTypes
-
-    parse_request
   end
 
-  def parse_request
-    parse_query
-    parse_body
-    parse_json
-    parse_url_params
+  {% for method in %w(url query body json) %}
+  def {{method.id}}
+    parse_{{method.id}}
+    @{{method.id}}
   end
+  {% end %}
 
   def parse_body
     return if (@request.headers["Content-Type"]? =~ /#{URL_ENCODED_FORM}/).nil?
@@ -39,7 +32,7 @@ class Kemal::ParamParser
     @query = parse_part(@request.query)
   end
 
-  def parse_url_params
+  def parse_url
     if params = @request.url_params
       params.each do |key, value|
         @url[key as String] = value as String

--- a/src/kemal/request.cr
+++ b/src/kemal/request.cr
@@ -11,7 +11,7 @@ class HTTP::Request
   private def check_for_method_override!
     @override_method = @method
     if @method == "POST"
-      params = Kemal::ParamParser.new(self).params.all
+      params = Kemal::ParamParser.new(self).params
       if params.has_key?("_method") && HTTP::Request.override_method_valid?(params["_method"])
         @override_method = params["_method"]
       end

--- a/src/kemal/request.cr
+++ b/src/kemal/request.cr
@@ -11,7 +11,7 @@ class HTTP::Request
   private def check_for_method_override!
     @override_method = @method
     if @method == "POST"
-      params = Kemal::ParamParser.new(self).params
+      params = Kemal::ParamParser.new(self).body
       if params.has_key?("_method") && HTTP::Request.override_method_valid?(params["_method"])
         @override_method = params["_method"]
       end

--- a/src/kemal/request.cr
+++ b/src/kemal/request.cr
@@ -11,7 +11,7 @@ class HTTP::Request
   private def check_for_method_override!
     @override_method = @method
     if @method == "POST"
-      params = Kemal::ParamParser.new(self).parse_request
+      params = Kemal::ParamParser.new(self).params.all
       if params.has_key?("_method") && HTTP::Request.override_method_valid?(params["_method"])
         @override_method = params["_method"]
       end


### PR DESCRIPTION
It now decouples `env.params` to `env.params.query`, `env.params.body`,
`env.params.json` and `env.params.url` and you still can access merged
values using `env.params.all`