### PR TITLE
Show backtrace in 500 statuses using `inspect_with_backtrace`

### DIFF
--- a/src/kemal/common_error_handler.cr
+++ b/src/kemal/common_error_handler.cr
@@ -5,11 +5,12 @@ class Kemal::CommonErrorHandler < HTTP::Handler
     begin
       call_next context
     rescue ex : Kemal::Exceptions::RouteNotFound
-      Kemal.config.logger.write("Exception: #{ex.to_s}\n")
+      Kemal.config.logger.write("Exception: #{ex.inspect_with_backtrace.colorize(:red)}\n")
       return render_404(context)
     rescue ex
-      Kemal.config.logger.write("Exception: #{ex.to_s}\n")
-      return render_500(context, ex.to_s)
+      Kemal.config.logger.write("Exception: #{ex.inspect_with_backtrace.colorize(:red)}\n")
+      verbosity = Kemal.config.env == "production" ? false : true
+      return render_500(context, ex.inspect_with_backtrace, verbosity)
     end
   end
 end

--- a/src/kemal/view.cr
+++ b/src/kemal/view.cr
@@ -46,7 +46,13 @@ def render_404(context)
 end
 
 # Template for 500 Internal Server Error
-def render_500(context, ex)
+def render_500(context, backtrace, verbosity)
+  message = if verbosity
+              "<pre>#{backtrace}</pre>"
+            else
+              "<p>Something wrong with the server :(</p>"
+            end
+
   template = <<-HTML
       <!DOCTYPE html>
       <html>
@@ -55,11 +61,14 @@ def render_500(context, ex)
         body { text-align:center;font-family:helvetica,arial;font-size:22px;
           color:#888;margin:20px}
         #c {margin:0 auto;width:500px;text-align:left}
+        pre {text-align:left;font-size:14px;color:#fff;background-color:#222;
+          font-family:Operator,"Source Code Pro",Menlo,Monaco,Inconsolata,monospace;
+          line-height:1.5;padding:10px;border-radius:2px;overflow:scroll}
         </style>
       </head>
       <body>
         <h2>Kemal has encountered an error. (500)</h2>
-        <p>#{ex}</p>
+        #{message}
       </body>
       </html>
   HTML


### PR DESCRIPTION
`Exception#to_s` is actually showing `Exception#message` and nothing else (https://github.com/crystal-lang/crystal/blob/60777f31ea84f8fd627bfec448ac86bd6221c161/src/exception.cr#L148)

- Converted it to `Exception#inspect_with_backtrace` (https://github.com/crystal-lang/crystal/blob/60777f31ea84f8fd627bfec448ac86bd6221c161/src/exception.cr#L160) to see. Put `:red` logs to the STDOUT via logger.
- Styled the backtrace in the HTML view.