### PR TITLE
Don't convert host_binding to slice when instantiating server

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -8,7 +8,7 @@ module Kemal
     config.setup
     config.add_handler Kemal::RouteHandler::INSTANCE
 
-    server = HTTP::Server.new(config.host_binding.not_nil!.to_slice, config.port, config.handlers)
+    server = HTTP::Server.new(config.host_binding.not_nil!, config.port, config.handlers)
     server.ssl = config.ssl
 
     Signal::INT.trap {


### PR DESCRIPTION
Hi,
I tried playing around with kemal today and this was breaking the example app. I see it's breaking the tests on current kemal master too. I honestly have no idea what I'm doing but it fixed the issue!