### PR TITLE
Support additional options as part of the Config

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -28,4 +28,19 @@ describe "Config" do
     config.add_handler CustomTestHandler.new
     config.handlers.size.should eq(5)
   end
+
+  it "adds custom options" do
+    config = Kemal.config
+    ARGV.push("--test")
+    ARGV.push("FOOBAR")
+    $test_option = nil
+
+    config.on_options = ->(parser : OptionParser) {
+      parser.on("--test TEST_OPTION", "Test an option") do |opt|
+        $test_option = opt
+      end
+    }
+    Kemal::CLI.new
+    $test_option.should eq("FOOBAR")
+  end
 end

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -35,7 +35,7 @@ describe "Config" do
     ARGV.push("FOOBAR")
     $test_option = nil
 
-    config.on_options = ->(parser : OptionParser) {
+    config.extra_options = ->(parser : OptionParser) {
       parser.on("--test TEST_OPTION", "Test an option") do |opt|
         $test_option = opt
       end

--- a/src/kemal/cli.cr
+++ b/src/kemal/cli.cr
@@ -35,6 +35,10 @@ module Kemal
           puts opts
           exit 0
         end
+        unless @config.on_options.nil?
+          c = @config.on_options.not_nil!
+          c.call opts
+        end
       end
     end
 

--- a/src/kemal/cli.cr
+++ b/src/kemal/cli.cr
@@ -35,8 +35,8 @@ module Kemal
           puts opts
           exit 0
         end
-        unless @config.on_options.nil?
-          c = @config.on_options.not_nil!
+        unless @config.extra_options.nil?
+          c = @config.extra_options.not_nil!
           c.call opts
         end
       end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -3,7 +3,7 @@ module Kemal
     INSTANCE = Config.new
     HANDLERS = [] of HTTP::Handler
     property host_binding, ssl, port, env, public_folder, logging,
-      always_rescue, error_handler, serve_static, run
+      always_rescue, error_handler, serve_static, run, on_options
 
     def initialize
       @host_binding = "0.0.0.0"
@@ -16,6 +16,7 @@ module Kemal
       @always_rescue = true
       @error_handler = nil
       @run = false
+      @on_options = nil
     end
 
     def logger

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -3,7 +3,7 @@ module Kemal
     INSTANCE = Config.new
     HANDLERS = [] of HTTP::Handler
     property host_binding, ssl, port, env, public_folder, logging,
-      always_rescue, error_handler, serve_static, run, on_options
+      always_rescue, error_handler, serve_static, run, extra_options
 
     def initialize
       @host_binding = "0.0.0.0"
@@ -16,7 +16,7 @@ module Kemal
       @always_rescue = true
       @error_handler = nil
       @run = false
-      @on_options = nil
+      @extra_options = nil
     end
 
     def logger


### PR DESCRIPTION
This commit adds the ability to add a closure suitable for adding
additional options. It is expected to allow someone to set global,
module or class level variables so they can pass changes/options
suitable for making decisions.

Solves #129 

I've tried multiple names (additional_options, additional_opts_func, on, ...) and the only one that seems unambiguous is `on_options`.

I wonder if Kemal::Config is a good place to put it. I've noticed that other pieces for configuration land there and it seems strange to land option configuration in Kemal::CLI when the rest of the application options are stuffed into Kemal::Config.

Thoughts?