### PR TITLE
Added return_with macro to break response blocks.

### DIFF
--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -34,4 +34,37 @@ describe "Macros" do
       config.logger.should be_a(CustomLogHandler)
     end
   end
+
+  describe "#return_with" do
+    it "can break block with return_with macro" do
+      get "/non-breaking" do |env|
+        "hello"
+        "world"
+      end
+      request = HTTP::Request.new("GET", "/non-breaking")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.body.should eq("world")
+
+      get "/breaking" do |env|
+        return_with env, 404, "hello"
+        "world"
+      end
+      request = HTTP::Request.new("GET", "/breaking")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(404)
+      client_response.body.should eq("hello")
+    end
+
+    it "can break block with return_with macro using default values" do
+      get "/" do |env|
+        return_with env
+        "world"
+      end
+      request = HTTP::Request.new("GET", "/")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.body.should eq("")
+    end
+  end
 end

--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -155,4 +155,5 @@ describe "Kemal::RouteHandler" do
     client_response.status_code.should eq(302)
     client_response.headers.has_key?("Location").should eq(true)
   end
+
 end

--- a/src/kemal/helpers.cr
+++ b/src/kemal/helpers.cr
@@ -15,6 +15,12 @@ macro render(filename, *args)
   Kilt.render({{filename}}, {{*args}})
 end
 
+macro return_with(env, status_code = 200, response = "")
+  {{env}}.response.status_code = {{status_code}}
+  {{env}}.response.print {{response}}
+  next
+end
+
 def add_handler(handler)
   Kemal.config.add_handler handler
 end
@@ -45,6 +51,7 @@ def logger(logger)
   Kemal.config.logger = logger
   Kemal.config.add_handler logger
 end
+
 
 def serve_static(status)
   Kemal.config.serve_static = status


### PR DESCRIPTION
Today with @askn we needed to return the block in the middle of the
code with a simple return but it was kinda tricky, needed to write
3 lines of code with next statement.

It may be easier to use a simple `return_with` macro.

```crystal
get "/" do
  if env.query["not_found"] == "1"
    return_with env, 404, "Not Found"
  end
  "hello world"
end
```

In this case, the server will response as "404: Not Found" in the case of `?not_found=1`
querystring is passed.