### PR TITLE
Update docs for the custom logger

### DIFF
--- a/_docs/middlewares.md
+++ b/_docs/middlewares.md
@@ -43,12 +43,12 @@ class MyCustomLogger < Kemal::BaseLogHandler
 end
 ```
 
-You need to register your custom logger with `logger` macro.
+You need to register your custom logger with `logger` config property.
 
 ```ruby
 require "kemal"
 
-logger MyCustomLogger.new
+Kemal.config.logger = MyCustomLogger.new(Kemal.config.env)
 ...
 ```
 


### PR DESCRIPTION
- The `logger` macro doesn't exist anymore
- Need to pass the `Kemal.config.env` to the logger initialize