### PR TITLE
Allow 404 error handler to be customizable

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -12,8 +12,10 @@ module Kemal
     config.server = HTTP::Server.new(config.host_binding.not_nil!, config.port, config.handlers)
     config.server.not_nil!.ssl = config.ssl
 
-    error 404 do |env|
-      render_404(env)
+    unless Kemal.config.error_handlers.has_key?(404)
+      error 404 do |env|
+        render_404
+      end
     end
 
     # Test environment doesn't need to have signal trap, built-in images, and logging.

--- a/src/kemal/common_exception_handler.cr
+++ b/src/kemal/common_exception_handler.cr
@@ -6,7 +6,10 @@ module Kemal
       begin
         call_next(context)
       rescue Kemal::Exceptions::RouteNotFound
-        return Kemal.config.error_handlers[404].call(context)
+        context.response.content_type = "text/html"
+        context.response.status_code = 404
+        context.response.print Kemal.config.error_handlers[404].call(context)
+        return context
       rescue Kemal::Exceptions::CustomException
         status_code = context.response.status_code
         if Kemal.config.error_handlers.has_key?(status_code)

--- a/src/kemal/view.cr
+++ b/src/kemal/view.cr
@@ -1,5 +1,5 @@
 # Template for 404 Not Found
-def render_404(context)
+def render_404
   template = <<-HTML
       <!DOCTYPE html>
       <html>
@@ -16,10 +16,6 @@ def render_404(context)
       </body>
       </html>
   HTML
-  context.response.content_type = "text/html"
-  context.response.status_code = 404
-  context.response.print template
-  context
 end
 
 # Template for 500 Internal Server Error


### PR DESCRIPTION
This allows the user to customize to 404 error handler like

```crystal
error 404 do |env|
  env.response.content_type = "application/json"
  {code: 404, message: "Not Found"}.to_json
end
```