### PR TITLE
Fix bad highlighting

### DIFF
--- a/_docs/views.md
+++ b/_docs/views.md
@@ -46,7 +46,7 @@ And you should use `content` variable (like `yield` in Rails) in layout file.
 Since Crystal does not allow using variables in macro literals, you need to generate
 another *helper macro* to make the code easier to read and write.
 
-```ruby
+```
 macro my_renderer(filename)
   render "my/app/view/base/path/#{{{filename}}}.ecr", "my/app/view/base/path/layouts/layout.ecr"
 end


### PR DESCRIPTION
Since Ruby doesn't know about macros, the filename variable is lost in the html output.