### PR TITLE
Fix SSL and specs for 0.18

### DIFF
--- a/spec/middleware/http_basic_auth_spec.cr
+++ b/spec/middleware/http_basic_auth_spec.cr
@@ -6,7 +6,7 @@ describe "Kemal::Middleware::HTTPBasicAuth" do
     request = HTTP::Request.new(
       "GET",
       "/",
-      headers: HTTP::Headers{"Authorization": "Basic c2VyZGFyOjEyMw=="},
+      headers: HTTP::Headers{"Authorization" => "Basic c2VyZGFyOjEyMw=="},
     )
 
     io_with_context = create_request_and_return_io(auth_handler, request)
@@ -19,7 +19,7 @@ describe "Kemal::Middleware::HTTPBasicAuth" do
     request = HTTP::Request.new(
       "GET",
       "/",
-      headers: HTTP::Headers{"Authorization": "NotBasic"},
+      headers: HTTP::Headers{"Authorization" => "NotBasic"},
     )
     io_with_context = create_request_and_return_io(auth_handler, request)
     client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)

--- a/spec/param_parser_spec.cr
+++ b/spec/param_parser_spec.cr
@@ -45,16 +45,16 @@ describe "ParamParser" do
       "POST",
       "/?hasan=cemal",
       body: "name=serdar&age=99",
-      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded"},
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"},
     )
 
     query_params = Kemal::ParamParser.new(request).query
-    {"hasan": "cemal"}.each do |k, v|
+    {"hasan" => "cemal"}.each do |k, v|
       query_params[k].should eq(v)
     end
 
     body_params = Kemal::ParamParser.new(request).body
-    {"name": "serdar", "age": "99"}.each do |k, v|
+    {"name" => "serdar", "age" => "99"}.each do |k, v|
       body_params[k].should eq(v)
     end
   end
@@ -69,7 +69,7 @@ describe "ParamParser" do
       "POST",
       "/",
       body: "hasan=cemal&hasan=lamec",
-      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded"},
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"},
     )
 
     body_params = Kemal::ParamParser.new(request).body
@@ -84,11 +84,11 @@ describe "ParamParser" do
         "POST",
         "/",
         body: "{\"name\": \"Serdar\"}",
-        headers: HTTP::Headers{"Content-Type": "application/json"},
+        headers: HTTP::Headers{"Content-Type" => "application/json"},
       )
 
       json_params = Kemal::ParamParser.new(request).json
-      json_params.should eq({"name": "Serdar"})
+      json_params.should eq({"name" => "Serdar"})
     end
 
     it "parses request body for array" do
@@ -98,11 +98,11 @@ describe "ParamParser" do
         "POST",
         "/",
         body: "[1]",
-        headers: HTTP::Headers{"Content-Type": "application/json"},
+        headers: HTTP::Headers{"Content-Type" => "application/json"},
       )
 
       json_params = Kemal::ParamParser.new(request).json
-      json_params.should eq({"_json": [1]})
+      json_params.should eq({"_json" => [1]})
     end
 
     it "parses request body and query params" do
@@ -112,16 +112,16 @@ describe "ParamParser" do
         "POST",
         "/?foo=bar",
         body: "[1]",
-        headers: HTTP::Headers{"Content-Type": "application/json"},
+        headers: HTTP::Headers{"Content-Type" => "application/json"},
       )
 
       query_params = Kemal::ParamParser.new(request).query
-      {"foo": "bar"}.each do |k, v|
+      {"foo" => "bar"}.each do |k, v|
         query_params[k].should eq(v)
       end
 
       json_params = Kemal::ParamParser.new(request).json
-      json_params.should eq({"_json": [1]})
+      json_params.should eq({"_json" => [1]})
     end
 
     it "handles no request body" do
@@ -130,7 +130,7 @@ describe "ParamParser" do
       request = HTTP::Request.new(
         "GET",
         "/",
-        headers: HTTP::Headers{"Content-Type": "application/json"},
+        headers: HTTP::Headers{"Content-Type" => "application/json"},
       )
 
       url_params = Kemal::ParamParser.new(request).url
@@ -160,7 +160,7 @@ describe "ParamParser" do
         "POST",
         "/?hasan=cemal",
         body: "name=serdar&age=99",
-        headers: HTTP::Headers{"Content-Type": "text/plain"},
+        headers: HTTP::Headers{"Content-Type" => "text/plain"},
       )
 
       query_params = Kemal::ParamParser.new(request).query

--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -49,7 +49,7 @@ describe "Kemal::RouteHandler" do
       "POST",
       "/",
       body: json_payload.to_json,
-      headers: HTTP::Headers{"Content-Type": "application/json"},
+      headers: HTTP::Headers{"Content-Type" => "application/json"},
     )
     client_response = call_request_on_app(request)
     client_response.body.should eq("Hello Serdar Age 26")
@@ -57,7 +57,7 @@ describe "Kemal::RouteHandler" do
 
   it "parses JSON with string array" do
     post "/" do |env|
-      skills = env.params.json["skills"] as Array
+      skills = env.params.json["skills"].as(Array)
       "Skills #{skills.each.join(',')}"
     end
 
@@ -66,7 +66,7 @@ describe "Kemal::RouteHandler" do
       "POST",
       "/",
       body: json_payload.to_json,
-      headers: HTTP::Headers{"Content-Type": "application/json"},
+      headers: HTTP::Headers{"Content-Type" => "application/json"},
     )
     client_response = call_request_on_app(request)
     client_response.body.should eq("Skills ruby,crystal")
@@ -74,9 +74,9 @@ describe "Kemal::RouteHandler" do
 
   it "parses JSON with json object array" do
     post "/" do |env|
-      skills = env.params.json["skills"] as Array
+      skills = env.params.json["skills"].as(Array)
       skills_from_languages = skills.map do |skill|
-        skill = skill as Hash
+        skill = skill.as(Hash)
         skill["language"]
       end
       "Skills #{skills_from_languages.each.join(',')}"
@@ -87,7 +87,7 @@ describe "Kemal::RouteHandler" do
       "POST",
       "/",
       body: json_payload.to_json,
-      headers: HTTP::Headers{"Content-Type": "application/json"},
+      headers: HTTP::Headers{"Content-Type" => "application/json"},
     )
 
     client_response = call_request_on_app(request)
@@ -102,7 +102,7 @@ describe "Kemal::RouteHandler" do
       "POST",
       "/",
       body: "_method=PUT",
-      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded"}
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"}
     )
     client_response = call_request_on_app(request)
     client_response.body.should eq("Hello World from PUT")
@@ -116,7 +116,7 @@ describe "Kemal::RouteHandler" do
       "POST",
       "/",
       body: "_method=PATCH",
-      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"}
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"}
     )
     client_response = call_request_on_app(request)
     client_response.body.should eq("Hello World from PATCH")
@@ -131,7 +131,7 @@ describe "Kemal::RouteHandler" do
       "POST",
       "/",
       body: "_method=DELETE",
-      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"}
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"}
     )
     client_response = call_request_on_app(request)
     client_response.body.should eq("Hello World from DELETE")

--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -4,9 +4,9 @@ describe "Kemal::WebSocketHandler" do
   it "doesn't match on wrong route" do
     handler = Kemal::WebSocketHandler.new "/" { }
     headers = HTTP::Headers{
-      "Upgrade":           "websocket",
-      "Connection":        "Upgrade",
-      "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+      "Upgrade"           => "websocket",
+      "Connection"        => "Upgrade",
+      "Sec-WebSocket-Key" => "dGhlIHNhbXBsZSBub25jZQ==",
     }
     request = HTTP::Request.new("GET", "/asd", headers)
     io_with_context = create_request_and_return_io(handler, request)
@@ -17,9 +17,9 @@ describe "Kemal::WebSocketHandler" do
   it "matches on given route" do
     handler = Kemal::WebSocketHandler.new "/" { }
     headers = HTTP::Headers{
-      "Upgrade":           "websocket",
-      "Connection":        "Upgrade",
-      "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+      "Upgrade"           => "websocket",
+      "Connection"        => "Upgrade",
+      "Sec-WebSocket-Key" => "dGhlIHNhbXBsZSBub25jZQ==",
     }
     request = HTTP::Request.new("GET", "/", headers)
     io_with_context = create_ws_request_and_return_io(handler, request)

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -10,7 +10,7 @@ module Kemal
     config.add_handler Kemal::RouteHandler::INSTANCE
 
     config.server = HTTP::Server.new(config.host_binding.not_nil!, config.port, config.handlers)
-    config.server.not_nil!.ssl = config.ssl
+    config.server.not_nil!.tls = config.ssl
 
     unless Kemal.config.error_handlers.has_key?(404)
       error 404 do |env|

--- a/src/kemal/cli.cr
+++ b/src/kemal/cli.cr
@@ -45,8 +45,8 @@ module Kemal
         puts "SSL Key Not Found"; exit unless @key_file
         puts "SSL Certificate Not Found"; exit unless @cert_file
         ssl = Kemal::Middleware::SSL.new
-        ssl.set_key_file @key_file.not_nil!.to_slice
-        ssl.set_cert_file @cert_file.not_nil!.to_slice
+        ssl.set_key_file @key_file.not_nil!
+        ssl.set_cert_file @cert_file.not_nil!
         Kemal.config.ssl = ssl.context
       end
     end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -3,7 +3,7 @@ module Kemal
     INSTANCE       = Config.new
     HANDLERS       = [] of HTTP::Handler
     ERROR_HANDLERS = {} of Int32 => HTTP::Server::Context -> String
-    @ssl : OpenSSL::SSL::Context?
+    @ssl : OpenSSL::SSL::Context::Server?
     @server : HTTP::Server?
 
     property host_binding, ssl, port, env, public_folder, logging,

--- a/src/kemal/middleware/ssl.cr
+++ b/src/kemal/middleware/ssl.cr
@@ -3,7 +3,7 @@ module Kemal::Middleware
     getter context
 
     def initialize
-      @context = OpenSSL::SSL::Context.new
+      @context = OpenSSL::SSL::Context::Server.new
     end
 
     def set_key_file(key_file)


### PR DESCRIPTION
Tuple literals are now declared with the old syntax for hash literals, breaking several specs. SSL has also been moved around a bit and renamed.