### PR TITLE
Add headers helper method

### DIFF
--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -67,4 +67,21 @@ describe "Macros" do
       client_response.body.should eq("")
     end
   end
+
+  describe "#headers" do
+    it "can add headers" do
+      get "/headers" do |env|
+        env.response.headers.add "Content-Type", "image/png"
+        headers env, {
+          "Access-Control-Allow-Origin" => "*",
+          "Content-Type" => "text/plain"
+        }
+      end
+
+      request = HTTP::Request.new("GET", "/headers")
+      response = call_request_on_app(request)
+      response.headers["Access-Control-Allow-Origin"].should eq("*")
+      response.headers["Content-Type"].should eq("text/plain")
+    end
+  end
 end

--- a/src/kemal/helpers.cr
+++ b/src/kemal/helpers.cr
@@ -57,3 +57,7 @@ end
 def serve_static(status)
   Kemal.config.serve_static = status
 end
+
+def headers(env, additional_headers)
+  env.response.headers.merge!(additional_headers)
+end


### PR DESCRIPTION
I was working on cloning a Sinatra app and it seemed like it had a much easier way to add multiple headers, so I thought it may be useful to have a similar syntax for Kemal. I also had trouble using the [example](http://kemalcr.com/docs/http-requests/) to add headers and had to do `env.response.headers.add("foo", "bar")` which was annoying.

Let me know if any of these PRs should be opened against a branch other than master for tagging/versioning purposes.