### PR TITLE
Fixing docs on adding headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Kemal Site (http://kemalcr.com)
+
+This is the repo for the official [Kemal](http://kemalcr.com) site.
+
+## Installation
+
+* `git clone git@github.com:sdogruyol/kemal.git`
+* `cd kemal`
+* `git fetch`
+* `git checkout gh-pages`
+* `gem install jekyll` requires [rubygems](http://rubygems.org)
+* `jekyll serve` boots website locally
+
+Now open up `http://locahost:4000` to view the site locally.
+
+## Contributing
+
+[![Join the chat at https://gitter.im/sdogruyol/kemal](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sdogruyol/kemal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+1. Fork the repo
+2. Make updates
+3. Ensure it all works locally for you first
+4. Triple check typos, etc...
+5. Submit pull request

--- a/_docs/context.md
+++ b/_docs/context.md
@@ -37,8 +37,8 @@ Accessing the HTTP request/response context (query params, body, content_type, h
 
   # Add headers to your response
   get "/headers" do |env|
-    env.add_header "Accept-Language", "tr"
-    env.add_header "Authorization", "Token 12345"
+    env.response.headers["Accept-Language"] = "tr"
+    env.response.headers["Authorization"] = "Token 12345"
   end
 ```
 


### PR DESCRIPTION
I've also added a simple `README.md` to the branch for others to be able to help contribute. The headers doc just removes `add_header` and replaces it with `env.response.headers`. Let me know if I need to make any other changes here.