### PR TITLE
Add send_file helper variation for sending raw data

### DIFF
--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -60,11 +60,11 @@ end
 
 # Send a file with given data and default `application/octet-stream` mime_type.
 #
-#   send_file env, "./path/to/file"
+#   send_file env, data_slice
 #
 # Optionally you can override the mime_type
 #
-#   send_file env, "./path/to/file", "image/jpeg"
+#   send_file env, data_slice, "image/jpeg"
 
 def send_file(env, data : Slice(UInt8), mime_type : String? = nil)
   mime_type ||= "application/octet-stream"

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -69,7 +69,7 @@ end
 def send_file(env, data : Slice(UInt8), mime_type : String? = nil)
   mime_type ||= "application/octet-stream"
 
-  env.response.headers.add "Content-Type", mime_type
+  env.response.content_type = mime_type
   env.response.content_length = data.bytesize
   env.response.write data
 end

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -57,3 +57,19 @@ def send_file(env, path : String, mime_type : String? = nil)
     IO.copy(file, env.response)
   end
 end
+
+# Send a file with given data and default `application/octet-stream` mime_type.
+#
+#   send_file env, "./path/to/file"
+#
+# Optionally you can override the mime_type
+#
+#   send_file env, "./path/to/file", "image/jpeg"
+
+def send_file(env, data : Slice(UInt8), mime_type : String? = nil)
+  mime_type ||= "application/octet-stream"
+
+  env.response.headers.add "Content-Type", mime_type
+  env.response.content_length = data.bytesize
+  env.response.write data
+end


### PR DESCRIPTION
It proves quite helpful when dealing with memory backed or remote resources since you don't have a physical file location you can provide.

Also, Thanks for making this library, it's a fun to use :)