### PR TITLE
Override `Content-Type` header key in send_file helper

### DIFF
--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -51,7 +51,7 @@ end
 def send_file(env, path : String, mime_type : String? = nil)
   file_path = File.expand_path(path, Dir.current)
   mime_type = "application/octet-stream" unless mime_type
-  env.response.headers.add "Content-Type", mime_type
+  env.response.content_type = mime_type
   env.response.content_length = File.size(file_path)
   File.open(file_path) do |file|
     IO.copy(file, env.response)


### PR DESCRIPTION
This effectively overrides `Content-Type` header key instead of adding another one, what you can see on the screenshot below:

![image](https://cloud.githubusercontent.com/assets/988/17467543/99e5387a-5d1f-11e6-80d7-43deadec5c82.png)
