### PR TITLE
Fix parsing JSON params when "charset" is present in "Content-Type" header

### DIFF
--- a/spec/param_parser_spec.cr
+++ b/spec/param_parser_spec.cr
@@ -91,6 +91,20 @@ describe "ParamParser" do
       json_params.should eq({"name" => "Serdar"})
     end
 
+    it "parses request body when passed charset" do
+      route = Route.new "POST", "/" { }
+
+      request = HTTP::Request.new(
+        "POST",
+        "/",
+        body: "{\"name\": \"Serdar\"}",
+        headers: HTTP::Headers{"Content-Type" => "application/json; charset=utf-8"},
+      )
+
+      json_params = Kemal::ParamParser.new(request).json
+      json_params.should eq({"name" => "Serdar"})
+    end
+
     it "parses request body for array" do
       route = Route.new "POST", "/" { }
 

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -55,7 +55,7 @@ module Kemal
     # If request body is a JSON Array it's added into `params` as `_json` and can be accessed
     # like params["_json"]
     def parse_json
-      return unless @request.body && @request.headers["Content-Type"]? == APPLICATION_JSON
+      return unless @request.body && @request.headers["Content-Type"]?.try(&.[APPLICATION_JSON]?)
 
       body = @request.body.as(String)
       case json = JSON.parse(body).raw


### PR DESCRIPTION
Resolves case when `Content-Type` header is passed in form of `application/json; charset=utf-8`.