### PR TITLE
Use String#starts_with? instead of String#[]?

### DIFF
--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -55,7 +55,7 @@ module Kemal
     # If request body is a JSON Array it's added into `params` as `_json` and can be accessed
     # like params["_json"]
     def parse_json
-      return unless @request.body && @request.headers["Content-Type"]?.try(&.[APPLICATION_JSON]?)
+      return unless @request.body && @request.headers["Content-Type"]?.try(&.starts_with?(APPLICATION_JSON))
 
       body = @request.body.as(String)
       case json = JSON.parse(body).raw


### PR DESCRIPTION
It shows real intention and covers cases when `application/json` is passed in the middle of the string, like `some_garbage_string; application/json`