### PR TITLE
Disable ssl when `-D without_openssl` is given

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -12,7 +12,9 @@ module Kemal
     config.add_handler Kemal::RouteHandler::INSTANCE
 
     config.server = HTTP::Server.new(config.host_binding, config.port, config.handlers)
+    {% if ! flag?(:without_openssl) %}
     config.server.tls = config.ssl
+    {% end %}
 
     Kemal::Sessions.run_reaper!
 

--- a/src/kemal/cli.cr
+++ b/src/kemal/cli.cr
@@ -39,6 +39,7 @@ module Kemal
     end
 
     def configure_ssl
+    {% if ! flag?(:without_openssl) %}
       if @ssl_enabled
         puts "SSL Key Not Found"; exit unless @key_file
         puts "SSL Certificate Not Found"; exit unless @cert_file
@@ -47,6 +48,7 @@ module Kemal
         ssl.set_cert_file @cert_file.not_nil!
         Kemal.config.ssl = ssl.context
       end
+    {% end %}
     end
 
     def read_env

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -8,7 +8,11 @@ module Kemal
     INSTANCE       = Config.new
     HANDLERS       = [] of HTTP::Handler
     ERROR_HANDLERS = {} of Int32 => HTTP::Server::Context -> String
+    {% if flag?(:without_openssl) %}
+    @ssl : Bool?
+    {% else %}
     @ssl : OpenSSL::SSL::Context::Server?
+    {% end %}
 
     property host_binding, ssl, port, env, public_folder, logging,
       always_rescue, serve_static, server, extra_options


### PR DESCRIPTION
### problem

Compilation fails with `-D without_openssl`

```shell
% crystal build --release --link-flags "-static" -D without_openssl sample.cr
Error in ./sample.cr:1: while requiring "./src/kemal"

require "./src/kemal"
^

in ./src/kemal.cr:2: while requiring "./kemal/*"

require "./kemal/*"
^

in ./src/kemal/config.cr:11: undefined constant OpenSSL::SSL::Context::Server

    @ssl : OpenSSL::SSL::Context::Server?
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

(tested on crystal-0.19.1)

### Motivations

We use `-D without_openssl`
- 1. when we compile codes statically on ubuntu-16.04 where it seems `libcrypto.a` is miss packaged.
  - further discussion: https://github.com/crystal-lang/crystal/issues/3182
- 2. when we need small static binary
  - For example: a binary size of statically compiled kemal app is
    - 6.3MB (default)
    - 3.8MB (without openssl)

###  PR

- All codes about `ssl` will be removed by macro when the `without_openssl` flag is given.
- No indents are inserted in macro context in order to reduce `git diff`

Thanks.