### PR TITLE
Adding port to Kemal#run

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -5,6 +5,8 @@ require "./kemal/middleware/*"
 
 module Kemal
   # The command to run a `Kemal` application.
+  # The port can be given to `#run` but is optionnal.
+  # If not given Kemal will use the default config port (`Kemal::Config#port`)
   def self.run(port = nil)
     Kemal::CLI.new
     config = Kemal.config

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -5,11 +5,12 @@ require "./kemal/middleware/*"
 
 module Kemal
   # The command to run a `Kemal` application.
-  def self.run
+  def self.run(port = nil)
     Kemal::CLI.new
     config = Kemal.config
     config.setup
     config.add_handler Kemal::RouteHandler::INSTANCE
+    config.port = port if port
 
     config.server = HTTP::Server.new(config.host_binding, config.port, config.handlers)
     {% if ! flag?(:without_openssl) %}


### PR DESCRIPTION
Simply adding the possibility to choose the port to listen on.

Permitting `Kemal.run(8080)` for example
and of course keep compatibility with `Kemal.run`