### PR TITLE
Improve session support

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -23,6 +23,14 @@ describe "Config" do
     config.host_binding.should eq "127.0.0.1"
   end
 
+  it "sets session values" do
+    config = Kemal.config
+    config.session["name"] = "kemal"
+    config.session["expire_time"] = 1.hours
+    config.session["name"].as(String).should eq "kemal"
+    config.session["expire_time"].as(Time::Span).should eq 1.hours
+  end
+
   it "adds a custom handler" do
     config = Kemal.config
     config.add_handler CustomTestHandler.new

--- a/spec/middleware/csrf_spec.cr
+++ b/spec/middleware/csrf_spec.cr
@@ -47,7 +47,7 @@ describe "Kemal::Middleware::CSRF" do
     client_response = HTTP::Client::Response.from_io(io, decompress: false)
     client_response.status_code.should eq 403
 
-    current_token = context.session["csrf"]
+    current_token = context.session["csrf"].as(String)
 
     handler = Kemal::Middleware::CSRF.new
     request = HTTP::Request.new("POST", "/",

--- a/spec/session_spec.cr
+++ b/spec/session_spec.cr
@@ -59,7 +59,6 @@ describe "Session" do
     age = nil
     awesome = nil
     velocity = nil
-    arr = nil
     get "/" do |env|
       sess = env.session
       who = sess["who"]?
@@ -71,7 +70,6 @@ describe "Session" do
       sess["age"] = 2016
       sess["velocity"] = 9999.9
       sess["awesome"] = true
-      sess["arr"] = [1, "Serdar", true, 90000.0]
       "Hello"
     end
 
@@ -84,6 +82,5 @@ describe "Session" do
     age.should eq 2016
     velocity.should eq 9999.9
     awesome.should eq true
-    arr.should eq [1, "Serdar", true, 90000.0]
   end
 end

--- a/spec/session_spec.cr
+++ b/spec/session_spec.cr
@@ -20,7 +20,7 @@ describe "Session" do
     # verify we got a cookie and session ID
     cookie = response.headers["Set-Cookie"]?
     cookie.should_not be_nil
-    response.cookies[Kemal::Sessions::NAME].value.should eq(sid)
+    response.cookies[Kemal.config.session["name"].as(String)].value.should eq(sid)
     lastsid = sid
     existing.should be_nil
 
@@ -33,7 +33,7 @@ describe "Session" do
     cookie2 = response.headers["Set-Cookie"]?
     cookie2.should_not be_nil
     cookie2.should eq(cookie)
-    response.cookies[Kemal::Sessions::NAME].value.should eq(lastsid)
+    response.cookies[Kemal.config.session["name"].as(String)].value.should eq(lastsid)
     existing.should eq("abc")
   end
 

--- a/spec/session_spec.cr
+++ b/spec/session_spec.cr
@@ -53,4 +53,37 @@ describe "Session" do
     Kemal::Sessions.prune!
     s.size.should eq(0)
   end
+
+  it "supports many types" do
+    who = nil
+    age = nil
+    awesome = nil
+    velocity = nil
+    arr = nil
+    get "/" do |env|
+      sess = env.session
+      who = sess["who"]?
+      age = sess["age"]?
+      velocity = sess["velocity"]?
+      awesome = sess["awesome"]?
+      arr = sess["arr"]?
+      sess["who"] = "Kemal"
+      sess["age"] = 2016
+      sess["velocity"] = 9999.9
+      sess["awesome"] = true
+      sess["arr"] = [1, "Serdar", true, 90000.0]
+      "Hello"
+    end
+
+    request = HTTP::Request.new("GET", "/")
+    response = call_request_on_app(request)
+    request = HTTP::Request.new("GET", "/", response.headers)
+    response = call_request_on_app(request)
+
+    who.should eq "Kemal"
+    age.should eq 2016
+    velocity.should eq 9999.9
+    awesome.should eq true
+    arr.should eq [1, "Serdar", true, 90000.0]
+  end
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -15,13 +15,14 @@ module Kemal
     {% end %}
 
     property host_binding, ssl, port, env, public_folder, logging,
-      always_rescue, serve_static : (Bool | Hash(String, Bool)), server, extra_options
+      always_rescue, serve_static : (Bool | Hash(String, Bool)), server, session : Hash(String, Time::Span | String), extra_options
 
     def initialize
       @host_binding = "0.0.0.0"
       @port = 3000
       @env = "development"
       @serve_static = {"dir_listing" => false, "gzip" => true}
+      @session = {"name" => "kemal_session", "expire_time" => 48.hours}
       @public_folder = "./public"
       @logging = true
       @logger = nil

--- a/src/kemal/session.cr
+++ b/src/kemal/session.cr
@@ -8,7 +8,7 @@ module Kemal
   #
   #   get("/") do |env|
   #     env.session["abc"] = "xyz"
-  #     uid = env.session["user_id"]?
+  #     uid = env.session["user_id"]?.as(Int32)
   #   end
   #
   # Note that only String values are allowed.

--- a/src/kemal/session.cr
+++ b/src/kemal/session.cr
@@ -17,6 +17,9 @@ module Kemal
   class Sessions
     NAME = "SessionId"
 
+    # Session Types are String, Integer, Float and Boolean
+    alias SessionTypes = String | Int64 | Float64 | Bool
+
     # I hate websites which require daily login so the default
     # inactivity timeout is 48 hours.
     TTL = 48.hours
@@ -38,7 +41,7 @@ module Kemal
 
       def initialize(@id)
         @last_access_at = Time.new.epoch_ms
-        @store = Hash(String, String).new
+        @store = Hash(String, SessionTypes).new
       end
 
       def [](key : String)
@@ -51,7 +54,7 @@ module Kemal
         @store[key]?
       end
 
-      def []=(key : String, value : String)
+      def []=(key : String, value : SessionTypes)
         @last_access_at = Time.now.epoch_ms
         @store[key] = value
       end
@@ -77,7 +80,7 @@ module Kemal
       @id = id
     end
 
-    def []=(key : String, value : String)
+    def []=(key : String, value : SessionTypes)
       store = STORE[id]? || begin
         STORE[id] = Session.new(id)
       end

--- a/src/kemal/session.cr
+++ b/src/kemal/session.cr
@@ -16,7 +16,7 @@ module Kemal
   # Sessions are pruned hourly after 48 hours of inactivity.
   class Sessions
     # Session Types are String, Integer, Float and Boolean
-    alias SessionTypes = String | Int64 | Float64 | Bool
+    alias SessionTypes = String | Int32 | Float64 | Bool | Array(String | Int32 | Float64 | Bool)
 
     # In-memory, ephemeral datastore only.
     #

--- a/src/kemal/session.cr
+++ b/src/kemal/session.cr
@@ -16,7 +16,7 @@ module Kemal
   # Sessions are pruned hourly after 48 hours of inactivity.
   class Sessions
     # Session Types are String, Integer, Float and Boolean
-    alias SessionTypes = String | Int32 | Float64 | Bool | Array(String | Int32 | Float64 | Bool)
+    alias SessionTypes = String | Int32 | Float64 | Bool
 
     # In-memory, ephemeral datastore only.
     #


### PR DESCRIPTION
Makes session support the following types

- String
- Int64
- Float64
- Bool

Make session name and expire_time configurable.

```crystal
Kemal.config.session["name"] = "kemal"
Kemal.config.session["expire_time"] = 1.hours
```

//cc @mperham 