### PR TITLE
Add API documentation generated by crystal doc

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+task :docs do
+  puts "Build docs..."
+  system "git checkout master > /dev/null 2>&1"
+  system "crystal doc > /dev/null 2>&1"
+  system "git checkout gh-pages > /dev/null 2>&1"
+end

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,8 @@ collections:
 nav_bars:
   - title: "Documentation"
     url: "/docs/getting_started"
+  - title: "API"
+    url: "/doc"
   - title: "Github"
     url: "https://github.com/sdogruyol/kemal"
 

--- a/doc/Kemal.html
+++ b/doc/Kemal.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="js/doc.js"></script>
+  <title>Kemal - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">module</span> Kemal
+
+</h1>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/base_log_handler.cr#L1" target="_blank">kemal/base_log_handler.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/cli.cr#L3" target="_blank">kemal/cli.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_exception_handler.cr#L1" target="_blank">kemal/common_exception_handler.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_log_handler.cr#L1" target="_blank">kemal/common_log_handler.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L1" target="_blank">kemal/config.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/init_handler.cr#L1" target="_blank">kemal/init_handler.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/null_log_handler.cr#L1" target="_blank">kemal/null_log_handler.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L3" target="_blank">kemal/param_parser.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route.cr#L1" target="_blank">kemal/route.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L3" target="_blank">kemal/route_handler.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L3" target="_blank">kemal/session.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/static_file_handler.cr#L5" target="_blank">kemal/static_file_handler.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/websocket_handler.cr#L1" target="_blank">kemal/websocket_handler.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal.cr#L6" target="_blank">kemal.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#config-class-method" class="signature"><strong>.config</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#config%28%26block%29-class-method" class="signature"><strong>.config</strong>(&block)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#run%28port%3Dnil%29-class-method" class="signature"><strong>.run</strong>(port = <span class="n">nil</span>)</a>
+        
+          <div class="summary"><p>The command to run a <code><a href="Kemal.html">Kemal</a></code> application.</p></div>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+
+
+<div class="methods-inherited">
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="config-class-method">
+      <div class="signature">
+        
+        def self.<strong>config</strong>
+
+        <a class="method-permalink" href="#config-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L105" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="config&#40;&amp;block&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>config</strong>(&block)
+
+        <a class="method-permalink" href="#config%28%26block%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L101" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="run&#40;port&#61;nil&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>run</strong>(port = <span class="n">nil</span>)
+
+        <a class="method-permalink" href="#run%28port%3Dnil%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>The command to run a <code><a href="Kemal.html">Kemal</a></code> application.
+The port can be given to <code><a href="Kemal.html#run%28port%3Dnil%29-class-method">#run</a></code> but is optional.
+If not given Kemal will use <code><a href="Kemal/Config.html#port%3AInt32-instance-method">Kemal::Config#port</a></code></p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal.cr#L10" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/AllParamTypes.html
+++ b/doc/Kemal/AllParamTypes.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::AllParamTypes - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">alias</span> Kemal::AllParamTypes
+
+</h1>
+
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>ParamParser parses the request contents including query_params and body
+and converts them into a params hash which you can within the environment
+context.</p>
+
+
+
+  <h2>Alias Definition</h2>
+  <code>Array(JSON::Type) | Bool | Float64 | Hash(String, JSON::Type) | Int64 | String | Nil</code>
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L7" target="_blank">kemal/param_parser.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+
+
+
+
+
+
+<div class="methods-inherited">
+  
+</div>
+
+
+
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/BaseLogHandler.html
+++ b/doc/Kemal/BaseLogHandler.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::BaseLogHandler - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">abstract class</span> Kemal::BaseLogHandler
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/BaseLogHandler.html">Kemal::BaseLogHandler</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>All loggers must inherit from <code><a href="../Kemal/BaseLogHandler.html">Kemal::BaseLogHandler</a></code>.</p>
+
+
+
+
+
+
+
+
+
+  <h2>Direct Known Subclasses</h2>
+  <ul class="other-types-list">
+  
+    <li class="other-type"><a href="../Kemal/CommonLogHandler.html">Kemal::CommonLogHandler</a></li>
+  
+    <li class="other-type"><a href="../Kemal/NullLogHandler.html">Kemal::NullLogHandler</a></li>
+  
+  </ul>
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/base_log_handler.cr#L3" target="_blank">kemal/base_log_handler.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#write%28message%29-instance-method" class="signature"><strong>#write</strong>(message)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        abstract 
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/base_log_handler.cr#L4" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="write&#40;message&#41;-instance-method">
+      <div class="signature">
+        abstract 
+        def <strong>write</strong>(message)
+
+        <a class="method-permalink" href="#write%28message%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/base_log_handler.cr#L5" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/CLI.html
+++ b/doc/Kemal/CLI.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::CLI - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::CLI
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/CLI.html">Kemal::CLI</a></li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Handles all the initialization from the command line.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/cli.cr#L5" target="_blank">kemal/cli.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new-class-method" class="signature"><strong>.new</strong></a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#configure_ssl-instance-method" class="signature"><strong>#configure_ssl</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#parse-instance-method" class="signature"><strong>#parse</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#read_env-instance-method" class="signature"><strong>#read_env</strong></a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>
+
+        <a class="method-permalink" href="#new-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/cli.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="configure_ssl-instance-method">
+      <div class="signature">
+        
+        def <strong>configure_ssl</strong>
+
+        <a class="method-permalink" href="#configure_ssl-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/cli.cr#L41" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="parse-instance-method">
+      <div class="signature">
+        
+        def <strong>parse</strong>
+
+        <a class="method-permalink" href="#parse-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/cli.cr#L16" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="read_env-instance-method">
+      <div class="signature">
+        
+        def <strong>read_env</strong>
+
+        <a class="method-permalink" href="#read_env-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/cli.cr#L54" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/CommonExceptionHandler.html
+++ b/doc/Kemal/CommonExceptionHandler.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::CommonExceptionHandler - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::CommonExceptionHandler
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/CommonExceptionHandler.html">Kemal::CommonExceptionHandler</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Kemal::CommonExceptionHandler handles all the exceptions including 404, custom errors and 500.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_exception_handler.cr#L3" target="_blank">kemal/common_exception_handler.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="INSTANCE">
+        <strong>INSTANCE</strong> = <code><span class="k">new</span></code>
+      </dt>
+      
+    
+  </dl>
+
+
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#call_exception_with_status_code%28context%2Cstatus_code%29-instance-method" class="signature"><strong>#call_exception_with_status_code</strong>(context, status_code)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_exception_handler.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="call_exception_with_status_code&#40;context,status_code&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call_exception_with_status_code</strong>(context, status_code)
+
+        <a class="method-permalink" href="#call_exception_with_status_code%28context%2Cstatus_code%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_exception_handler.cr#L21" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/CommonLogHandler.html
+++ b/doc/Kemal/CommonLogHandler.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::CommonLogHandler - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::CommonLogHandler
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/CommonLogHandler.html">Kemal::CommonLogHandler</a></li><li class="superclass"><a href="../Kemal/BaseLogHandler.html">Kemal::BaseLogHandler</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Kemal::CommonLogHandler uses STDOUT by default and handles the logging of request/response process time.
+It's also provides a <code><a href="../Kemal/CommonLogHandler.html#write%28message%29-instance-method">#write</a></code> method for common logging purposes.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_log_handler.cr#L4" target="_blank">kemal/common_log_handler.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28io%3AIO%3DSTDOUT%29-class-method" class="signature"><strong>.new</strong>(io : IO = <span class="t">STDOUT</span>)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#write%28message%29-instance-method" class="signature"><strong>#write</strong>(message)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+  <h3>Instance methods inherited from class <code><a href="../Kemal/BaseLogHandler.html">Kemal::BaseLogHandler</a></code></h3>
+  
+  
+    <a href="../Kemal/BaseLogHandler.html#call%28context%29-instance-method" class="tooltip">
+      <span>call(context)</span>
+    call</a>, 
+    
+  
+    <a href="../Kemal/BaseLogHandler.html#write%28message%29-instance-method" class="tooltip">
+      <span>write(message)</span>
+    write</a>
+    
+  
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;io:IO&#61;STDOUT&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(io : IO = <span class="t">STDOUT</span>)
+
+        <a class="method-permalink" href="#new%28io%3AIO%3DSTDOUT%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_log_handler.cr#L7" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_log_handler.cr#L11" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="write&#40;message&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>write</strong>(message)
+
+        <a class="method-permalink" href="#write%28message%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/common_log_handler.cr#L19" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Config.html
+++ b/doc/Kemal/Config.html
@@ -1,0 +1,991 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::Config - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Config
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/Config.html">Kemal::Config</a></li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Kemal::Config stores all the configuration options for a Kemal application.
+It's a singleton and you can access it like.</p>
+
+<p>Kemal.config</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L7" target="_blank">kemal/config.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="ERROR_HANDLERS">
+        <strong>ERROR_HANDLERS</strong> = <code>{} <span class="k">of</span> <span class="t">Int32</span> => (<span class="t">HTTP</span><span class="t">::</span><span class="t">Server</span><span class="t">::</span><span class="t">Context</span> -> <span class="t">String</span>)</code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="HANDLERS">
+        <strong>HANDLERS</strong> = <code><span class="o">[]</span> <span class="k">of</span> <span class="t">HTTP</span><span class="t">::</span><span class="t">Handler</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="INSTANCE">
+        <strong>INSTANCE</strong> = <code><span class="t">Config</span>.<span class="k">new</span></code>
+      </dt>
+      
+    
+  </dl>
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new-class-method" class="signature"><strong>.new</strong></a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#add_error_handler%28status_code%2C%26handler%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method" class="signature"><strong>#add_error_handler</strong>(status_code, &handler : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#add_handler%28handler%3AHTTP%3A%3AHandler%29-instance-method" class="signature"><strong>#add_handler</strong>(handler : HTTP::Handler)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#add_ws_handler%28handler%3AHTTP%3A%3AWebSocketHandler%29-instance-method" class="signature"><strong>#add_ws_handler</strong>(handler : HTTP::WebSocketHandler)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#always_rescue%3ABool-instance-method" class="signature"><strong>#always_rescue</strong> : Bool</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#always_rescue%3D%28always_rescue%29-instance-method" class="signature"><strong>#always_rescue=</strong>(always_rescue)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#env%3AString-instance-method" class="signature"><strong>#env</strong> : String</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#env%3D%28env%29-instance-method" class="signature"><strong>#env=</strong>(env)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#error_handlers-instance-method" class="signature"><strong>#error_handlers</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#extra_options%3ANil%7COptionParser-%3ENil-instance-method" class="signature"><strong>#extra_options</strong> : Nil | OptionParser -> Nil</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#extra_options%28%26extra_options%3AOptionParser-%3E%29-instance-method" class="signature"><strong>#extra_options</strong>(&extra_options : OptionParser -> )</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#extra_options%3D%28extra_options%29-instance-method" class="signature"><strong>#extra_options=</strong>(extra_options)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#handlers-instance-method" class="signature"><strong>#handlers</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#host_binding%3AString-instance-method" class="signature"><strong>#host_binding</strong> : String</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#host_binding%3D%28host_binding%29-instance-method" class="signature"><strong>#host_binding=</strong>(host_binding)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#logger-instance-method" class="signature"><strong>#logger</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#logger%3D%28logger%3AKemal%3A%3ABaseLogHandler%29-instance-method" class="signature"><strong>#logger=</strong>(logger : Kemal::BaseLogHandler)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#logging%3ABool-instance-method" class="signature"><strong>#logging</strong> : Bool</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#logging%3D%28logging%29-instance-method" class="signature"><strong>#logging=</strong>(logging)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#port%3AInt32-instance-method" class="signature"><strong>#port</strong> : Int32</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#port%3D%28port%29-instance-method" class="signature"><strong>#port=</strong>(port)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#public_folder%3AString-instance-method" class="signature"><strong>#public_folder</strong> : String</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#public_folder%3D%28public_folder%29-instance-method" class="signature"><strong>#public_folder=</strong>(public_folder)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#scheme-instance-method" class="signature"><strong>#scheme</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#serve_static%3ABool%7CHash%28String%2CBool%29-instance-method" class="signature"><strong>#serve_static</strong> : Bool | Hash(String, Bool)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#serve_static%3D%28serve_static%3ABool%7CHash%28String%2CBool%29%29-instance-method" class="signature"><strong>#serve_static=</strong>(serve_static : Bool | Hash(String, Bool))</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#server%3AHTTP%3A%3AServer-instance-method" class="signature"><strong>#server</strong> : HTTP::Server</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#server%3D%28server%29-instance-method" class="signature"><strong>#server=</strong>(server)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#session%3AHash%28String%2CTime%3A%3ASpan%7CString%29-instance-method" class="signature"><strong>#session</strong> : Hash(String, Time::Span | String)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#session%3D%28session%3AHash%28String%2CTime%3A%3ASpan%7CString%29%29-instance-method" class="signature"><strong>#session=</strong>(session : Hash(String, Time::Span | String))</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#setup-instance-method" class="signature"><strong>#setup</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#ssl%3ANil%7COpenSSL%3A%3ASSL%3A%3AContext%3A%3AServer-instance-method" class="signature"><strong>#ssl</strong> : Nil | OpenSSL::SSL::Context::Server</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#ssl%3D%28ssl%29-instance-method" class="signature"><strong>#ssl=</strong>(ssl)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>
+
+        <a class="method-permalink" href="#new-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L20" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="add_error_handler&#40;status_code,&amp;handler:HTTP::Server::Context-&gt;_&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>add_error_handler</strong>(status_code, &handler : <a href="../HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#add_error_handler%28status_code%2C%26handler%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L62" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="add_handler&#40;handler:HTTP::Handler&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>add_handler</strong>(handler : HTTP::Handler)
+
+        <a class="method-permalink" href="#add_handler%28handler%3AHTTP%3A%3AHandler%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L50" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="add_ws_handler&#40;handler:HTTP::WebSocketHandler&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>add_ws_handler</strong>(handler : HTTP::WebSocketHandler)
+
+        <a class="method-permalink" href="#add_ws_handler%28handler%3AHTTP%3A%3AWebSocketHandler%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L54" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="always_rescue:Bool-instance-method">
+      <div class="signature">
+        
+        def <strong>always_rescue</strong> : Bool
+
+        <a class="method-permalink" href="#always_rescue%3ABool-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="always_rescue&#61;&#40;always_rescue&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>always_rescue=</strong>(always_rescue)
+
+        <a class="method-permalink" href="#always_rescue%3D%28always_rescue%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="env:String-instance-method">
+      <div class="signature">
+        
+        def <strong>env</strong> : String
+
+        <a class="method-permalink" href="#env%3AString-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="env&#61;&#40;env&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>env=</strong>(env)
+
+        <a class="method-permalink" href="#env%3D%28env%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="error_handlers-instance-method">
+      <div class="signature">
+        
+        def <strong>error_handlers</strong>
+
+        <a class="method-permalink" href="#error_handlers-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L58" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="extra_options:Nil|OptionParser-&gt;Nil-instance-method">
+      <div class="signature">
+        
+        def <strong>extra_options</strong> : Nil | OptionParser -> Nil
+
+        <a class="method-permalink" href="#extra_options%3ANil%7COptionParser-%3ENil-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="extra_options&#40;&amp;extra_options:OptionParser-&gt;&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>extra_options</strong>(&extra_options : OptionParser -> )
+
+        <a class="method-permalink" href="#extra_options%28%26extra_options%3AOptionParser-%3E%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L66" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="extra_options&#61;&#40;extra_options&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>extra_options=</strong>(extra_options)
+
+        <a class="method-permalink" href="#extra_options%3D%28extra_options%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="handlers-instance-method">
+      <div class="signature">
+        
+        def <strong>handlers</strong>
+
+        <a class="method-permalink" href="#handlers-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L46" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="host_binding:String-instance-method">
+      <div class="signature">
+        
+        def <strong>host_binding</strong> : String
+
+        <a class="method-permalink" href="#host_binding%3AString-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="host_binding&#61;&#40;host_binding&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>host_binding=</strong>(host_binding)
+
+        <a class="method-permalink" href="#host_binding%3D%28host_binding%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="logger-instance-method">
+      <div class="signature">
+        
+        def <strong>logger</strong>
+
+        <a class="method-permalink" href="#logger-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L34" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="logger&#61;&#40;logger:Kemal::BaseLogHandler&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>logger=</strong>(logger : <a href="../Kemal/BaseLogHandler.html">Kemal::BaseLogHandler</a>)
+
+        <a class="method-permalink" href="#logger%3D%28logger%3AKemal%3A%3ABaseLogHandler%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L38" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="logging:Bool-instance-method">
+      <div class="signature">
+        
+        def <strong>logging</strong> : Bool
+
+        <a class="method-permalink" href="#logging%3ABool-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="logging&#61;&#40;logging&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>logging=</strong>(logging)
+
+        <a class="method-permalink" href="#logging%3D%28logging%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="port:Int32-instance-method">
+      <div class="signature">
+        
+        def <strong>port</strong> : Int32
+
+        <a class="method-permalink" href="#port%3AInt32-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="port&#61;&#40;port&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>port=</strong>(port)
+
+        <a class="method-permalink" href="#port%3D%28port%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="public_folder:String-instance-method">
+      <div class="signature">
+        
+        def <strong>public_folder</strong> : String
+
+        <a class="method-permalink" href="#public_folder%3AString-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="public_folder&#61;&#40;public_folder&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>public_folder=</strong>(public_folder)
+
+        <a class="method-permalink" href="#public_folder%3D%28public_folder%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="scheme-instance-method">
+      <div class="signature">
+        
+        def <strong>scheme</strong>
+
+        <a class="method-permalink" href="#scheme-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L42" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="serve_static:Bool|Hash&#40;String,Bool&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>serve_static</strong> : Bool | Hash(String, Bool)
+
+        <a class="method-permalink" href="#serve_static%3ABool%7CHash%28String%2CBool%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="serve_static&#61;&#40;serve_static:Bool|Hash&#40;String,Bool&#41;&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>serve_static=</strong>(serve_static : Bool | Hash(String, Bool))
+
+        <a class="method-permalink" href="#serve_static%3D%28serve_static%3ABool%7CHash%28String%2CBool%29%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="server:HTTP::Server-instance-method">
+      <div class="signature">
+        
+        def <strong>server</strong> : <a href="../HTTP/Server.html">HTTP::Server</a>
+
+        <a class="method-permalink" href="#server%3AHTTP%3A%3AServer-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="server&#61;&#40;server&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>server=</strong>(server)
+
+        <a class="method-permalink" href="#server%3D%28server%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="session:Hash&#40;String,Time::Span|String&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>session</strong> : Hash(String, Time::Span | String)
+
+        <a class="method-permalink" href="#session%3AHash%28String%2CTime%3A%3ASpan%7CString%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="session&#61;&#40;session:Hash&#40;String,Time::Span|String&#41;&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>session=</strong>(session : Hash(String, Time::Span | String))
+
+        <a class="method-permalink" href="#session%3D%28session%3AHash%28String%2CTime%3A%3ASpan%7CString%29%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="setup-instance-method">
+      <div class="signature">
+        
+        def <strong>setup</strong>
+
+        <a class="method-permalink" href="#setup-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L69" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="ssl:Nil|OpenSSL::SSL::Context::Server-instance-method">
+      <div class="signature">
+        
+        def <strong>ssl</strong> : Nil | OpenSSL::SSL::Context::Server
+
+        <a class="method-permalink" href="#ssl%3ANil%7COpenSSL%3A%3ASSL%3A%3AContext%3A%3AServer-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="ssl&#61;&#40;ssl&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>ssl=</strong>(ssl)
+
+        <a class="method-permalink" href="#ssl%3D%28ssl%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/config.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Exceptions.html
+++ b/doc/Kemal/Exceptions.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::Exceptions - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent current" data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">module</span> Kemal::Exceptions
+
+</h1>
+
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Exceptions for 404 and custom errors are defined here.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/exceptions.cr#L2" target="_blank">kemal/exceptions.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+
+
+
+
+
+
+<div class="methods-inherited">
+  
+</div>
+
+
+
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Exceptions/CustomException.html
+++ b/doc/Kemal/Exceptions/CustomException.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Exceptions::CustomException - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Exceptions::CustomException
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../../Kemal/Exceptions/CustomException.html">Kemal::Exceptions::CustomException</a></li><li class="superclass">Exception</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/exceptions.cr#L9" target="_blank">kemal/exceptions.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28context%29-class-method" class="signature"><strong>.new</strong>(context)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;context&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(context)
+
+        <a class="method-permalink" href="#new%28context%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/exceptions.cr#L10" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Exceptions/RouteNotFound.html
+++ b/doc/Kemal/Exceptions/RouteNotFound.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Exceptions::RouteNotFound - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Exceptions::RouteNotFound
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../../Kemal/Exceptions/RouteNotFound.html">Kemal::Exceptions::RouteNotFound</a></li><li class="superclass">Exception</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/exceptions.cr#L3" target="_blank">kemal/exceptions.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28context%29-class-method" class="signature"><strong>.new</strong>(context)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;context&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(context)
+
+        <a class="method-permalink" href="#new%28context%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/exceptions.cr#L4" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/InitHandler.html
+++ b/doc/Kemal/InitHandler.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::InitHandler - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::InitHandler
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/InitHandler.html">Kemal::InitHandler</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Kemal::InitHandler is the first handler thus initializes the context with default values such as
+Content-Type, X-Powered-By.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/init_handler.cr#L4" target="_blank">kemal/init_handler.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="INSTANCE">
+        <strong>INSTANCE</strong> = <code><span class="k">new</span></code>
+      </dt>
+      
+    
+  </dl>
+
+
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/init_handler.cr#L7" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Middleware.html
+++ b/doc/Kemal/Middleware.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::Middleware - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">module</span> Kemal::Middleware
+
+</h1>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/csrf.cr#L3" target="_blank">kemal/middleware/csrf.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L1" target="_blank">kemal/middleware/filters.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/http_basic_auth.cr#L3" target="_blank">kemal/middleware/http_basic_auth.cr</a>
+    
+    <br/>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/ssl.cr#L1" target="_blank">kemal/middleware/ssl.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+
+
+
+
+
+
+<div class="methods-inherited">
+  
+</div>
+
+
+
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Middleware/Block.html
+++ b/doc/Kemal/Middleware/Block.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Middleware::Block - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Middleware::Block
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../../Kemal/Middleware/Block.html">Kemal::Middleware::Block</a></li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L73" target="_blank">kemal/middleware/filters.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>.new</strong>(&block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#block%3AHTTP%3A%3AServer%3A%3AContext-%3EString-instance-method" class="signature"><strong>#block</strong> : HTTP::Server::Context -> String</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#block%3D%28block%3AHTTP%3A%3AServer%3A%3AContext-%3EString%29-instance-method" class="signature"><strong>#block=</strong>(block : HTTP::Server::Context -> String)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(&block : <a href="../../HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#new%28%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L76" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="block:HTTP::Server::Context-&gt;String-instance-method">
+      <div class="signature">
+        
+        def <strong>block</strong> : <a href="../../HTTP/Server/Context.html">HTTP::Server::Context</a> -> String
+
+        <a class="method-permalink" href="#block%3AHTTP%3A%3AServer%3A%3AContext-%3EString-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L74" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="block&#61;&#40;block:HTTP::Server::Context-&gt;String&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>block=</strong>(block : <a href="../../HTTP/Server/Context.html">HTTP::Server::Context</a> -> String)
+
+        <a class="method-permalink" href="#block%3D%28block%3AHTTP%3A%3AServer%3A%3AContext-%3EString%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L74" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L80" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Middleware/CSRF.html
+++ b/doc/Kemal/Middleware/CSRF.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Middleware::CSRF - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Middleware::CSRF
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../../Kemal/Middleware/CSRF.html">Kemal::Middleware::CSRF</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>This middleware adds CSRF protection to your application.</p>
+
+<p>Returns 403 "Forbidden" unless the current CSRF token is submitted
+with any non-GET/HEAD request.</p>
+
+<p>Without CSRF protection, your app is vulnerable to replay attacks
+where an attacker can re-submit a form.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/csrf.cr#L12" target="_blank">kemal/middleware/csrf.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="ALLOWED_METHODS">
+        <strong>ALLOWED_METHODS</strong> = <code>[<span class="s">&quot;GET&quot;</span>, <span class="s">&quot;HEAD&quot;</span>, <span class="s">&quot;OPTIONS&quot;</span>, <span class="s">&quot;TRACE&quot;</span>] <span class="k">of</span> <span class="t">::</span><span class="t">String</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="HEADER">
+        <strong>HEADER</strong> = <code><span class="s">&quot;X_CSRF_TOKEN&quot;</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="PARAMETER_NAME">
+        <strong>PARAMETER_NAME</strong> = <code><span class="s">&quot;authenticity_token&quot;</span></code>
+      </dt>
+      
+    
+  </dl>
+
+
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/csrf.cr#L17" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Middleware/Filter.html
+++ b/doc/Kemal/Middleware/Filter.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Middleware::Filter - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Middleware::Filter
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../../Kemal/Middleware/Filter.html">Kemal::Middleware::Filter</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Kemal::Filter handle all code that should be evaluated before and after
+every request</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L4" target="_blank">kemal/middleware/filters.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="INSTANCE">
+        <strong>INSTANCE</strong> = <code><span class="k">new</span></code>
+      </dt>
+      
+    
+  </dl>
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new-class-method" class="signature"><strong>.new</strong></a>
+        
+          <div class="summary"><p>This middleware is lazily instantiated and added to the handlers as soon as a call to <code>after_X</code> or <code>before_X</code> is made.</p></div>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#_add_route_filter%28verb%2Cpath%2Ctype%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method" class="signature"><strong>#_add_route_filter</strong>(verb, path, type, &block : HTTP::Server::Context -> _)</a>
+        
+          <div class="summary"><p>:nodoc: This shouldn't be called directly, it's not private because I need to call it for testing purpose since I can't call the macros in the spec.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#after%28verb%2Cpath%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method" class="signature"><strong>#after</strong>(verb, path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+          <div class="summary"><p>This can be called directly but it's simpler to just use the macros, it will check if another filter is not already defined for this verb/path/type and proceed to call <code>add_route_filter</code></p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#before%28verb%2Cpath%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method" class="signature"><strong>#before</strong>(verb, path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+          <div class="summary"><p>This can be called directly but it's simpler to just use the macros, it will check if another filter is not already defined for this verb/path/type and proceed to call <code>add_route_filter</code></p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+          <div class="summary"><p>The call order of the filters is before_all -> before_x -> X -> after_x -> after_all</p></div>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>
+
+        <a class="method-permalink" href="#new-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>This middleware is lazily instantiated and added to the handlers as soon as a call to <code>after_X</code> or <code>before_X</code> is made.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L8" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="_add_route_filter&#40;verb,path,type,&amp;block:HTTP::Server::Context-&gt;_&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>_add_route_filter</strong>(verb, path, type, &block : <a href="../../HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#_add_route_filter%28verb%2Cpath%2Ctype%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method">#</a>
+      </div>
+      
+        <div class="doc"><p>:nodoc: This shouldn't be called directly, it's not private because I need to call it for testing purpose since I can't call the macros in the spec.
+It adds the block for the corresponding verb/path/type combination to the tree.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L29" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="after&#40;verb,path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>after</strong>(verb, path = <span class="s">&quot;*&quot;</span>, &block : <a href="../../HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#after%28verb%2Cpath%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method">#</a>
+      </div>
+      
+        <div class="doc"><p>This can be called directly but it's simpler to just use the macros, it will check if another filter is not already defined for this verb/path/type and proceed to call <code>add_route_filter</code></p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L44" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="before&#40;verb,path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>before</strong>(verb, path = <span class="s">&quot;*&quot;</span>, &block : <a href="../../HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#before%28verb%2Cpath%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method">#</a>
+      </div>
+      
+        <div class="doc"><p>This can be called directly but it's simpler to just use the macros, it will check if another filter is not already defined for this verb/path/type and proceed to call <code>add_route_filter</code></p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L39" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+        <div class="doc"><p>The call order of the filters is before_all -> before_x -> X -> after_x -> after_all</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L14" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Middleware/HTTPBasicAuth.html
+++ b/doc/Kemal/Middleware/HTTPBasicAuth.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Middleware::HTTPBasicAuth - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Middleware::HTTPBasicAuth
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../../Kemal/Middleware/HTTPBasicAuth.html">Kemal::Middleware::HTTPBasicAuth</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>This middleware adds HTTP Basic Auth support to your application.
+Returns 401 "Unauthorized" with wrong credentials.</p>
+
+<p>auth_handler = Kemal::Middleware::HTTPBasicAuth.new("username", "password")
+Kemal.config.add_handler auth_handler</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/http_basic_auth.cr#L10" target="_blank">kemal/middleware/http_basic_auth.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="AUTH">
+        <strong>AUTH</strong> = <code><span class="s">&quot;Authorization&quot;</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="AUTH_MESSAGE">
+        <strong>AUTH_MESSAGE</strong> = <code><span class="s">&quot;Could not verify your access level for that URL.\nYou have to login with proper credentials&quot;</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="BASIC">
+        <strong>BASIC</strong> = <code><span class="s">&quot;Basic&quot;</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="HEADER_LOGIN_REQUIRED">
+        <strong>HEADER_LOGIN_REQUIRED</strong> = <code><span class="s">&quot;Basic realm&#61;\&quot;Login Required\&quot;&quot;</span></code>
+      </dt>
+      
+    
+  </dl>
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28username%3AString%7CNil%2Cpassword%3AString%7CNil%29-class-method" class="signature"><strong>.new</strong>(username : String | Nil, password : String | Nil)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#authorized%3F%28value%29-instance-method" class="signature"><strong>#authorized?</strong>(value)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;username:String|Nil,password:String|Nil&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(username : String | Nil, password : String | Nil)
+
+        <a class="method-permalink" href="#new%28username%3AString%7CNil%2Cpassword%3AString%7CNil%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/http_basic_auth.cr#L16" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="authorized?&#40;value&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>authorized?</strong>(value)
+
+        <a class="method-permalink" href="#authorized%3F%28value%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/http_basic_auth.cr#L33" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/http_basic_auth.cr#L19" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Middleware/SSL.html
+++ b/doc/Kemal/Middleware/SSL.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Middleware::SSL - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Middleware::SSL
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../../Kemal/Middleware/SSL.html">Kemal::Middleware::SSL</a></li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>This middleware adds SSL / TLS support.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/ssl.cr#L3" target="_blank">kemal/middleware/ssl.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new-class-method" class="signature"><strong>.new</strong></a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#context%3AOpenSSL%3A%3ASSL%3A%3AContext%3A%3AServer-instance-method" class="signature"><strong>#context</strong> : OpenSSL::SSL::Context::Server</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#set_cert_file%28cert_file%29-instance-method" class="signature"><strong>#set_cert_file</strong>(cert_file)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#set_key_file%28key_file%29-instance-method" class="signature"><strong>#set_key_file</strong>(key_file)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>
+
+        <a class="method-permalink" href="#new-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/ssl.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="context:OpenSSL::SSL::Context::Server-instance-method">
+      <div class="signature">
+        
+        def <strong>context</strong> : OpenSSL::SSL::Context::Server
+
+        <a class="method-permalink" href="#context%3AOpenSSL%3A%3ASSL%3A%3AContext%3A%3AServer-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/ssl.cr#L4" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="set_cert_file&#40;cert_file&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>set_cert_file</strong>(cert_file)
+
+        <a class="method-permalink" href="#set_cert_file%28cert_file%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/ssl.cr#L14" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="set_key_file&#40;key_file&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>set_key_file</strong>(key_file)
+
+        <a class="method-permalink" href="#set_key_file%28key_file%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/ssl.cr#L10" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/NullLogHandler.html
+++ b/doc/Kemal/NullLogHandler.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::NullLogHandler - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::NullLogHandler
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/NullLogHandler.html">Kemal::NullLogHandler</a></li><li class="superclass"><a href="../Kemal/BaseLogHandler.html">Kemal::BaseLogHandler</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>This is here to represent the logger corresponding to Null Object Pattern.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/null_log_handler.cr#L3" target="_blank">kemal/null_log_handler.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#write%28message%29-instance-method" class="signature"><strong>#write</strong>(message)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+  <h3>Instance methods inherited from class <code><a href="../Kemal/BaseLogHandler.html">Kemal::BaseLogHandler</a></code></h3>
+  
+  
+    <a href="../Kemal/BaseLogHandler.html#call%28context%29-instance-method" class="tooltip">
+      <span>call(context)</span>
+    call</a>, 
+    
+  
+    <a href="../Kemal/BaseLogHandler.html#write%28message%29-instance-method" class="tooltip">
+      <span>write(message)</span>
+    write</a>
+    
+  
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/null_log_handler.cr#L4" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="write&#40;message&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>write</strong>(message)
+
+        <a class="method-permalink" href="#write%28message%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/null_log_handler.cr#L8" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/ParamParser.html
+++ b/doc/Kemal/ParamParser.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::ParamParser - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::ParamParser
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/ParamParser.html">Kemal::ParamParser</a></li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L9" target="_blank">kemal/param_parser.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="APPLICATION_JSON">
+        <strong>APPLICATION_JSON</strong> = <code><span class="s">&quot;application/json&quot;</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="URL_ENCODED_FORM">
+        <strong>URL_ENCODED_FORM</strong> = <code><span class="s">&quot;application/x-www-form-urlencoded&quot;</span></code>
+      </dt>
+      
+    
+  </dl>
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28request%3AHTTP%3A%3ARequest%29-class-method" class="signature"><strong>.new</strong>(request : HTTP::Request)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#body-instance-method" class="signature"><strong>#body</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#json-instance-method" class="signature"><strong>#json</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#parse_body-instance-method" class="signature"><strong>#parse_body</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#parse_json-instance-method" class="signature"><strong>#parse_json</strong></a>
+        
+          <div class="summary"><p>Parses JSON request body if Content-Type is <code>application/json</code>.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#parse_part%28part%29-instance-method" class="signature"><strong>#parse_part</strong>(part)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#parse_query-instance-method" class="signature"><strong>#parse_query</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#parse_url-instance-method" class="signature"><strong>#parse_url</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#query-instance-method" class="signature"><strong>#query</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#url-instance-method" class="signature"><strong>#url</strong></a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;request:HTTP::Request&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(request : <a href="../HTTP/Request.html">HTTP::Request</a>)
+
+        <a class="method-permalink" href="#new%28request%3AHTTP%3A%3ARequest%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L13" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="body-instance-method">
+      <div class="signature">
+        
+        def <strong>body</strong>
+
+        <a class="method-permalink" href="#body-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L24" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="json-instance-method">
+      <div class="signature">
+        
+        def <strong>json</strong>
+
+        <a class="method-permalink" href="#json-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L24" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="parse_body-instance-method">
+      <div class="signature">
+        
+        def <strong>parse_body</strong>
+
+        <a class="method-permalink" href="#parse_body-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L36" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="parse_json-instance-method">
+      <div class="signature">
+        
+        def <strong>parse_json</strong>
+
+        <a class="method-permalink" href="#parse_json-instance-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Parses JSON request body if Content-Type is <code>application/json</code>.
+If request body is a JSON Hash then all the params are parsed and added into <code>params</code>.
+If request body is a JSON Array it's added into <code>params</code> as <code>_json</code> and can be accessed
+like params["_json"]</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L57" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="parse_part&#40;part&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>parse_part</strong>(part)
+
+        <a class="method-permalink" href="#parse_part%28part%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L71" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="parse_query-instance-method">
+      <div class="signature">
+        
+        def <strong>parse_query</strong>
+
+        <a class="method-permalink" href="#parse_query-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L41" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="parse_url-instance-method">
+      <div class="signature">
+        
+        def <strong>parse_url</strong>
+
+        <a class="method-permalink" href="#parse_url-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L45" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="query-instance-method">
+      <div class="signature">
+        
+        def <strong>query</strong>
+
+        <a class="method-permalink" href="#query-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L24" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="url-instance-method">
+      <div class="signature">
+        
+        def <strong>url</strong>
+
+        <a class="method-permalink" href="#url-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/param_parser.cr#L24" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Route.html
+++ b/doc/Kemal/Route.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::Route - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Route
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/Route.html">Kemal::Route</a></li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Route is the main building block of Kemal.
+It takes 3 parameters: Method, path and a block to specify
+what action to be done if the route is matched.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route.cr#L5" target="_blank">kemal/route.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28method%2Cpath%3AString%2C%26handler%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>.new</strong>(method, path : String, &handler : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#handler%3AHTTP%3A%3AServer%3A%3AContext-%3EString-instance-method" class="signature"><strong>#handler</strong> : HTTP::Server::Context -> String</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;method,path:String,&amp;handler:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(method, path : String, &handler : <a href="../HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#new%28method%2Cpath%3AString%2C%26handler%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route.cr#L10" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="handler:HTTP::Server::Context-&gt;String-instance-method">
+      <div class="signature">
+        
+        def <strong>handler</strong> : <a href="../HTTP/Server/Context.html">HTTP::Server::Context</a> -> String
+
+        <a class="method-permalink" href="#handler%3AHTTP%3A%3AServer%3A%3AContext-%3EString-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/RouteHandler.html
+++ b/doc/Kemal/RouteHandler.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::RouteHandler - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::RouteHandler
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/RouteHandler.html">Kemal::RouteHandler</a></li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Kemal::RouteHandler is the main handler which handles all the HTTP requests. Routing, parsing, rendering e.g
+are done in this handler.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L6" target="_blank">kemal/route_handler.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="INSTANCE">
+        <strong>INSTANCE</strong> = <code><span class="k">new</span></code>
+      </dt>
+      
+    
+  </dl>
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new-class-method" class="signature"><strong>.new</strong></a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#add_route%28method%2Cpath%2C%26handler%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method" class="signature"><strong>#add_route</strong>(method, path, &handler : HTTP::Server::Context -> _)</a>
+        
+          <div class="summary"><p>Adds a given route to routing tree.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#lookup_route%28verb%2Cpath%29-instance-method" class="signature"><strong>#lookup_route</strong>(verb, path)</a>
+        
+          <div class="summary"><p>Check if a route is defined and returns the lookup</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#process_request%28context%29-instance-method" class="signature"><strong>#process_request</strong>(context)</a>
+        
+          <div class="summary"><p>Processes the route if it's a match.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#tree%3ARadix%3A%3ATree%28Kemal%3A%3ARoute%29-instance-method" class="signature"><strong>#tree</strong> : Radix::Tree(Kemal::Route)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#tree%3D%28tree%29-instance-method" class="signature"><strong>#tree=</strong>(tree)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>
+
+        <a class="method-permalink" href="#new-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L11" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="add_route&#40;method,path,&amp;handler:HTTP::Server::Context-&gt;_&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>add_route</strong>(method, path, &handler : <a href="../HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#add_route%28method%2Cpath%2C%26handler%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-instance-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Adds a given route to routing tree. As an exception each <code>GET</code> route additionaly defines
+a corresponding <code>HEAD</code> route.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L21" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L15" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="lookup_route&#40;verb,path&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>lookup_route</strong>(verb, path)
+
+        <a class="method-permalink" href="#lookup_route%28verb%2Cpath%29-instance-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Check if a route is defined and returns the lookup</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L27" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="process_request&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>process_request</strong>(context)
+
+        <a class="method-permalink" href="#process_request%28context%29-instance-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Processes the route if it's a match. Otherwise renders 404.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L32" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="tree:Radix::Tree&#40;Kemal::Route&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>tree</strong> : Radix::Tree(<a href="../Kemal/Route.html">Kemal::Route</a>)
+
+        <a class="method-permalink" href="#tree%3ARadix%3A%3ATree%28Kemal%3A%3ARoute%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L9" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="tree&#61;&#40;tree&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>tree=</strong>(tree)
+
+        <a class="method-permalink" href="#tree%3D%28tree%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/route_handler.cr#L9" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Sessions.html
+++ b/doc/Kemal/Sessions.html
@@ -1,0 +1,504 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::Sessions - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent current" data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Sessions
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/Sessions.html">Kemal::Sessions</a></li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Kemal's default session is in-memory only and holds simple String values only.
+The client-side cookie stores a random ID.</p>
+
+<p>Kemal handlers can access the session like so:</p>
+
+<p>get("/") do |env|
+env.session["abc"] = "xyz"
+uid = env.session["user_id"]?.as(Int32)
+end</p>
+
+<p>Note that only String values are allowed.</p>
+
+<p>Sessions are pruned hourly after 48 hours of inactivity.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L17" target="_blank">kemal/session.cr</a>
+    
+    <br/>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="STORE">
+        <strong>STORE</strong> = <code><span class="t">Hash</span>(<span class="t">String</span>, <span class="t">Session</span>).<span class="k">new</span></code>
+      </dt>
+      
+      <dd class="entry-const-doc">
+        <p>In-memory, ephemeral datastore only.</p>
+
+<p>Implementing Redis or Memcached as a datastore
+is left as an exercise to another reader.</p>
+
+<p>Note that the only thing we store on the client-side
+is an opaque, random String.  If we actually wanted to
+store any data, we'd need to implement encryption, key
+rotation, tamper-detection and that whole iceberg.</p>
+      </dd>
+      
+    
+  </dl>
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28ctx%3AHTTP%3A%3AServer%3A%3AContext%29-class-method" class="signature"><strong>.new</strong>(ctx : HTTP::Server::Context)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#prune%21%28before%3D%28Time.now-%28%28Kemal.config.session%5B%26quot%3Bexpire_time%26quot%3B%5D%29.as%28Time%3A%3ASpan%29%29%29.epoch_ms%29-class-method" class="signature"><strong>.prune!</strong>(before = (<span class="t">Time</span>.now <span class="o">-</span> ((<span class="t">Kemal</span>.config.session[<span class="s">&quot;expire_time&quot;</span>]).<span class="k">as</span>(<span class="t">Time</span><span class="t">::</span><span class="t">Span</span>))).epoch_ms)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#run_reaper%21-class-method" class="signature"><strong>.run_reaper!</strong></a>
+        
+          <div class="summary"><p>This is an hourly job to prune the in-memory hash of any sessions which have expired due to inactivity, otherwise we'll have a slow memory leak and possible DDoS vector.</p></div>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#%5B%5D%28key%3AString%29-instance-method" class="signature"><strong>#[]</strong>(key : String)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#%5B%5D%3D%28key%3AString%2Cvalue%3ASessionTypes%29-instance-method" class="signature"><strong>#[]=</strong>(key : String, value : SessionTypes)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#%5B%5D%3F%28key%3AString%29-instance-method" class="signature"><strong>#[]?</strong>(key : String)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#delete%28key%3AString%29-instance-method" class="signature"><strong>#delete</strong>(key : String)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#id-instance-method" class="signature"><strong>#id</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#id%3F%3ANil%7CString-instance-method" class="signature"><strong>#id?</strong> : Nil | String</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;ctx:HTTP::Server::Context&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(ctx : <a href="../HTTP/Server/Context.html">HTTP::Server::Context</a>)
+
+        <a class="method-permalink" href="#new%28ctx%3AHTTP%3A%3AServer%3A%3AContext%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L64" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="prune&#33;&#40;before&#61;&#40;Time.now-&#40;&#40;Kemal.config.session&#91;&amp;quot;expire_time&amp;quot;&#93;&#41;.as&#40;Time::Span&#41;&#41;&#41;.epoch_ms&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>prune!</strong>(before = (<span class="t">Time</span>.now <span class="o">-</span> ((<span class="t">Kemal</span>.config.session[<span class="s">&quot;expire_time&quot;</span>]).<span class="k">as</span>(<span class="t">Time</span><span class="t">::</span><span class="t">Span</span>))).epoch_ms)
+
+        <a class="method-permalink" href="#prune%21%28before%3D%28Time.now-%28%28Kemal.config.session%5B%26quot%3Bexpire_time%26quot%3B%5D%29.as%28Time%3A%3ASpan%29%29%29.epoch_ms%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L96" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="run_reaper&#33;-class-method">
+      <div class="signature">
+        
+        def self.<strong>run_reaper!</strong>
+
+        <a class="method-permalink" href="#run_reaper%21-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>This is an hourly job to prune the in-memory hash of any
+sessions which have expired due to inactivity, otherwise
+we'll have a slow memory leak and possible DDoS vector.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L104" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="&#91;&#93;&#40;key:String&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>[]</strong>(key : String)
+
+        <a class="method-permalink" href="#%5B%5D%28key%3AString%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L84" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="&#91;&#93;&#61;&#40;key:String,value:SessionTypes&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>[]=</strong>(key : String, value : <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>)
+
+        <a class="method-permalink" href="#%5B%5D%3D%28key%3AString%2Cvalue%3ASessionTypes%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L77" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="&#91;&#93;?&#40;key:String&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>[]?</strong>(key : String)
+
+        <a class="method-permalink" href="#%5B%5D%3F%28key%3AString%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L88" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="delete&#40;key:String&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>delete</strong>(key : String)
+
+        <a class="method-permalink" href="#delete%28key%3AString%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L92" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="id-instance-method">
+      <div class="signature">
+        
+        def <strong>id</strong>
+
+        <a class="method-permalink" href="#id-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L62" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="id?:Nil|String-instance-method">
+      <div class="signature">
+        
+        def <strong>id?</strong> : Nil | String
+
+        <a class="method-permalink" href="#id%3F%3ANil%7CString-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L62" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Sessions/Session.html
+++ b/doc/Kemal/Sessions/Session.html
@@ -1,0 +1,475 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Sessions::Session - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::Sessions::Session
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../../Kemal/Sessions/Session.html">Kemal::Sessions::Session</a></li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L32" target="_blank">kemal/session.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28id%29-class-method" class="signature"><strong>.new</strong>(id)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#%5B%5D%28key%3AString%29-instance-method" class="signature"><strong>#[]</strong>(key : String)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#%5B%5D%3D%28key%3AString%2Cvalue%3ASessionTypes%29-instance-method" class="signature"><strong>#[]=</strong>(key : String, value : SessionTypes)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#%5B%5D%3F%28key%3AString%29-instance-method" class="signature"><strong>#[]?</strong>(key : String)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#delete%28key%3AString%29-instance-method" class="signature"><strong>#delete</strong>(key : String)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#id-instance-method" class="signature"><strong>#id</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#id%3F%3ANil%7CString-instance-method" class="signature"><strong>#id?</strong> : Nil | String</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#last_access_at-instance-method" class="signature"><strong>#last_access_at</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#last_access_at%3D%28last_access_at%3AInt64%29-instance-method" class="signature"><strong>#last_access_at=</strong>(last_access_at : Int64)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#last_access_at%3F%3AInt64%7CNil-instance-method" class="signature"><strong>#last_access_at?</strong> : Int64 | Nil</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;id&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(id)
+
+        <a class="method-permalink" href="#new%28id%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L36" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="&#91;&#93;&#40;key:String&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>[]</strong>(key : String)
+
+        <a class="method-permalink" href="#%5B%5D%28key%3AString%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L41" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="&#91;&#93;&#61;&#40;key:String,value:SessionTypes&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>[]=</strong>(key : String, value : <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>)
+
+        <a class="method-permalink" href="#%5B%5D%3D%28key%3AString%2Cvalue%3ASessionTypes%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L51" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="&#91;&#93;?&#40;key:String&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>[]?</strong>(key : String)
+
+        <a class="method-permalink" href="#%5B%5D%3F%28key%3AString%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L46" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="delete&#40;key:String&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>delete</strong>(key : String)
+
+        <a class="method-permalink" href="#delete%28key%3AString%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L56" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="id-instance-method">
+      <div class="signature">
+        
+        def <strong>id</strong>
+
+        <a class="method-permalink" href="#id-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L33" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="id?:Nil|String-instance-method">
+      <div class="signature">
+        
+        def <strong>id?</strong> : Nil | String
+
+        <a class="method-permalink" href="#id%3F%3ANil%7CString-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L33" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="last_access_at-instance-method">
+      <div class="signature">
+        
+        def <strong>last_access_at</strong>
+
+        <a class="method-permalink" href="#last_access_at-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="last_access_at&#61;&#40;last_access_at:Int64&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>last_access_at=</strong>(last_access_at : Int64)
+
+        <a class="method-permalink" href="#last_access_at%3D%28last_access_at%3AInt64%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L34" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="last_access_at?:Int64|Nil-instance-method">
+      <div class="signature">
+        
+        def <strong>last_access_at?</strong> : Int64 | Nil
+
+        <a class="method-permalink" href="#last_access_at%3F%3AInt64%7CNil-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/Sessions/SessionTypes.html
+++ b/doc/Kemal/Sessions/SessionTypes.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../../js/doc.js"></script>
+  <title>Kemal::Sessions::SessionTypes - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">alias</span> Kemal::Sessions::SessionTypes
+
+</h1>
+
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Session Types are String, Integer, Float and Boolean</p>
+
+
+
+  <h2>Alias Definition</h2>
+  <code>Bool | Float64 | Int32 | String</code>
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/session.cr#L19" target="_blank">kemal/session.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+
+
+
+
+
+
+<div class="methods-inherited">
+  
+</div>
+
+
+
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/StaticFileHandler.html
+++ b/doc/Kemal/StaticFileHandler.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::StaticFileHandler - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::StaticFileHandler
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/StaticFileHandler.html">Kemal::StaticFileHandler</a></li><li class="superclass">HTTP::StaticFileHandler</li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/static_file_handler.cr#L6" target="_blank">kemal/static_file_handler.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#etag%28context%2Cfile_path%29-instance-method" class="signature"><strong>#etag</strong>(context, file_path)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#mime_type%28path%29-instance-method" class="signature"><strong>#mime_type</strong>(path)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#zip_types%28path%29-instance-method" class="signature"><strong>#zip_types</strong>(path)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/static_file_handler.cr#L7" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="etag&#40;context,file_path&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>etag</strong>(context, file_path)
+
+        <a class="method-permalink" href="#etag%28context%2Cfile_path%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/static_file_handler.cr#L79" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="mime_type&#40;path&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>mime_type</strong>(path)
+
+        <a class="method-permalink" href="#mime_type%28path%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/static_file_handler.cr#L92" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="zip_types&#40;path&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>zip_types</strong>(path)
+
+        <a class="method-permalink" href="#zip_types%28path%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/static_file_handler.cr#L88" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/Kemal/WebSocketHandler.html
+++ b/doc/Kemal/WebSocketHandler.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="../css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="../js/doc.js"></script>
+  <title>Kemal::WebSocketHandler - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="../index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="../toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent open current" data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="../Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="../Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="../Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="../Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="../Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="../Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="../Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="../Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="../Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="../Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="../Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="../Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="../Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="../Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="../Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="../Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="../Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="../Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="../Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="../Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="../Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="../Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="../Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="../Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="../Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="../Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  <span class="kind">class</span> Kemal::WebSocketHandler
+
+</h1>
+
+
+  <ul class="superclass-hierarchy"><li class="superclass"><a href="../Kemal/WebSocketHandler.html">Kemal::WebSocketHandler</a></li><li class="superclass">HTTP::WebSocketHandler</li><li class="superclass">HTTP::Handler</li><li class="superclass">Reference</li><li class="superclass">Object</li></ul>
+
+
+
+
+  <h2>Overview</h2>
+
+  <p>Kemal::WebSocketHandler is used for building a WebSocket route.
+For each WebSocket route a new handler is created and registered to global handlers.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+    
+      <a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/websocket_handler.cr#L4" target="_blank">kemal/websocket_handler.cr</a>
+    
+    <br/>
+  
+
+
+
+
+
+  <h2>Class Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#new%28path%3AString%2C%26proc%3AHTTP%3A%3AWebSocket%2CHTTP%3A%3AServer%3A%3AContext-%3EVoid%29-class-method" class="signature"><strong>.new</strong>(path : String, &proc : HTTP::WebSocket, HTTP::Server::Context -> Void)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+  <h2>Instance Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#call%28context%29-instance-method" class="signature"><strong>#call</strong>(context)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+<div class="methods-inherited">
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+    
+
+
+    
+
+
+  
+</div>
+
+
+  <h2>Class Method Detail</h2>
+  
+    <div class="entry-detail" id="new&#40;path:String,&amp;proc:HTTP::WebSocket,HTTP::Server::Context-&gt;Void&#41;-class-method">
+      <div class="signature">
+        
+        def self.<strong>new</strong>(path : String, &proc : HTTP::WebSocket, <a href="../HTTP/Server/Context.html">HTTP::Server::Context</a> -> Void)
+
+        <a class="method-permalink" href="#new%28path%3AString%2C%26proc%3AHTTP%3A%3AWebSocket%2CHTTP%3A%3AServer%3A%3AContext-%3EVoid%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/websocket_handler.cr#L5" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+  <h2>Instance Method Detail</h2>
+  
+    <div class="entry-detail" id="call&#40;context&#41;-instance-method">
+      <div class="signature">
+        
+        def <strong>call</strong>(context)
+
+        <a class="method-permalink" href="#call%28context%29-instance-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/websocket_handler.cr#L9" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+</div>
+
+</body>
+</html>

--- a/doc/css/style.css
+++ b/doc/css/style.css
@@ -1,0 +1,328 @@
+html, body {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  font-family: "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif;
+  color: #333;
+}
+
+a {
+  color: #263F6C;
+}
+
+a:visited {
+  color: #112750;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 30px 0;
+}
+
+h1.type-name {
+  color: #47266E;
+}
+
+#types-list, #main-content {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  overflow: auto;
+}
+
+#types-list {
+  left: 0;
+  width: 20%;
+  background-color: #2E1052;
+}
+
+#types-list #search-box {
+  padding: 5px;
+}
+
+#types-list input {
+  display: block;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 5px;
+  font: inherit;
+  font-family: inherit;
+  line-height: 1.2;
+  width: 100%;
+  border: 0;
+  border-radius: 50px;
+  outline: 0;
+}
+
+#types-list ul {
+  margin: 0;
+  padding: 0;
+  list-style: none outside;
+}
+
+#types-list li {
+  display: block;
+  position: relative;
+}
+
+#types-list li.hide {
+  display: none;
+}
+
+#types-list a {
+  display: block;
+  padding: 5px 15px 5px 30px;
+  text-decoration: none;
+  color: #fff;
+}
+
+#types-list .current > a,
+#types-list a:hover {
+  color: #866BA6;
+}
+
+#types-list li ul {
+  overflow: hidden;
+  height: 0;
+  max-height: 0;
+  transition: 1s ease-in-out;
+}
+
+
+#types-list li.parent {
+  padding-left: 30px;
+}
+
+#types-list li.parent::before {
+  box-sizing: border-box;
+  content: "▼";
+  display: block;
+  width: 30px;
+  height: 30px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  text-align: center;
+  color: white;
+  font-size: 8px;
+  line-height: 30px;
+  transform: rotateZ(-90deg);
+  cursor: pointer;
+  transition: .2s linear;
+}
+
+
+#types-list li.parent > a {
+  padding-left: 0;
+}
+
+#types-list li.parent.open::before {
+  transform: rotateZ(0);
+}
+
+#types-list li.open > ul {
+  height: auto;
+  max-height: 1000em;
+}
+
+#main-content {
+  padding: 0 30px 30px 30px;
+  left: 20%;
+  right: 0;
+}
+
+.kind {
+  font-size: 60%;
+  color: #866BA6;
+}
+
+.superclass-hierarchy {
+  margin: -15px 0 30px 0;
+  padding: 0;
+  list-style: none outside;
+  font-size: 80%;
+}
+
+.superclass-hierarchy .superclass {
+  display: inline-block;
+  margin: 0 7px 0 0;
+  padding: 0;
+}
+
+.superclass-hierarchy .superclass + .superclass::before {
+  content: "<";
+  margin-right: 7px;
+}
+
+.other-types-list li {
+  display: inline-block;
+}
+
+.other-types-list,
+.list-summary {
+  margin: 0 0 30px 0;
+  padding: 0;
+  list-style: none outside;
+}
+
+.entry-const {
+  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+}
+
+.entry-summary {
+  padding-bottom: 4px;
+}
+
+.superclass-hierarchy .superclass a,
+.other-type a,
+.entry-summary .signature {
+  padding: 4px 8px;
+  margin-bottom: 4px;
+  display: inline-block;
+  background-color: #f8f8f8;
+  color: #47266E;
+  border: 1px solid #f0f0f0;
+  text-decoration: none;
+  border-radius: 3px;
+}
+
+.superclass-hierarchy .superclass a:hover,
+.other-type a:hover,
+.entry-summary .signature:hover {
+  background: #D5CAE3;
+  border-color: #624288;
+}
+
+.entry-summary .summary {
+  padding-left: 32px;
+}
+
+.entry-summary a {
+  text-decoration: none;
+}
+
+.entry-detail {
+  padding: 30px 0;
+}
+
+.entry-detail .signature {
+  position: relative;
+  padding: 5px 15px;
+  margin-bottom: 10px;
+  display: block;
+  border-radius: 5px;
+  background-color: #f8f8f8;
+  color: #47266E;
+  border: 1px solid #f0f0f0;
+  transition: .2s ease-in-out;
+}
+
+.entry-detail:target .signature {
+  background-color: #D5CAE3;
+  border: 1px solid #624288;
+}
+
+.entry-detail .signature .method-permalink {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 5px 15px;
+  text-decoration: none;
+  font-weight: bold;
+  color: #624288;
+}
+
+.methods-inherited {
+  padding-right: 10%;
+  line-height: 1.5em;
+}
+
+.methods-inherited h3 {
+  margin-bottom: 4px;
+}
+
+.methods-inherited a {
+  display: inline-block;
+  text-decoration: none;
+  color: #47266E;
+}
+
+.methods-inherited a:hover {
+  text-decoration: underline;
+  color: #6C518B;
+}
+
+.methods-inherited .tooltip>span {
+  background: #D5CAE3;
+  padding: 4px 8px;
+  border-radius: 3px;
+  margin: -4px -8px;
+}
+
+.methods-inherited .tooltip * {
+    color: #47266E;
+}
+
+pre {
+  padding: 10px 20px;
+  margin-top: 4px;
+  border-radius: 3px;
+  line-height: 1.45;
+  overflow: auto;
+  color: #333;
+  background: #f7f7f7;
+  font-size: 14px;
+}
+
+code {
+  font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+}
+
+.tooltip>span {
+  position: absolute;
+  opacity: 0;
+  display: none;
+  pointer-events: none;
+}
+
+.tooltip:hover>span {
+  display: inline-block;
+  opacity: 1;
+}
+
+.c {
+  color: #969896;
+}
+
+.n {
+  color: #0086b3;
+}
+
+.t {
+  color: #0086b3;
+}
+
+.s {
+  color: #183691;
+}
+
+.i {
+  color: #7f5030;
+}
+
+.k {
+  color: #a71d5d;
+}
+
+.o {
+  color: #a71d5d;
+}
+
+.m {
+  color: #795da3;
+}

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="js/doc.js"></script>
+  <title>README - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li class="current"><a href="index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<p>&lt;img src="https://avatars3.githubusercontent.com/u/15321198?v=3&s=200" width="100" height="100" />
+# Kemal <a href="https://travis-ci.org/sdogruyol/kemal" target="_blank"><img src="https://travis-ci.org/sdogruyol/kemal.svg?branch=master" alt="Build Status"/></a></p>
+
+<p><a href="https://gitter.im/sdogruyol/kemal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge" target="_blank"><img src="https://badges.gitter.im/Join%20Chat.svg" alt="Join the chat at https://gitter.im/sdogruyol/kemal"/></a></p>
+
+<p>Lightning Fast, Super Simple web framework for <a href="http://www.crystal-lang.org" target="_blank">Crystal</a>.
+Inspired by <a href="http://www.sinatrarb.com/" target="_blank">Sinatra</a> but with superior performance and built-in WebSocket support.</p>
+
+<h1>Super Simple ⚡️</h1>
+
+<pre><code class='language-ruby'>require "kemal"
+
+# Matches GET "http://host:port/"
+get "/" do
+  "Hello World!"
+end
+
+# Creates a WebSocket handler.
+# Matches "ws://host:port/socket"
+ws "/socket" do |socket|
+  socket.send "Hello from Kemal!"
+end
+
+Kemal.run</code></pre>
+
+<p>Start your application!</p>
+
+<pre><code>crystal src<span class="s">/kemal_sample.cr</code></pre>
+
+<p>Go to <em>http://localhost:3000</em></p>
+
+<p>Check <a href="http://kemalcr.com" target="_blank">documentation</a> or <a href="https://github.com/sdogruyol/kemal/tree/master/samples" target="_blank">samples</a> for more.</p>
+
+<h1>Super Fast 🚀</h1>
+
+<p>Numbers speak louder than words.</p>
+
+<p>| Framework             | Request Per Second  | Avg. Response Time |
+| --------------------- | :-----------------: | -----------------: |
+| Kemal (Production)    | 100238              |           395.44μs |
+| Sinatra (Thin)        | 2274                |            43.82ms |</p>
+
+<p>These results were achieved with <code></code><code>wrk</code><code></code> on a Macbook Pro Late 2013. (<strong>2Ghz i7 8GB Ram OS X Yosemite</strong>)</p>
+
+<h1>Features</h1>
+
+<ul><li>Support all REST verbs</li><li>Websocket support</li><li>Request/Response context, easy parameter handling</li><li>Middlewares</li><li>Built-in JSON support</li><li>Built-in static file serving</li><li>Built-in view templating via <a href="https://github.com/jeromegn/kilt" target="_blank">Kilt</a></li></ul>
+
+<h1>Documentation</h1>
+
+<p>You can read the documentation at the official site <a href="http://kemalcr.com" target="_blank">kemalcr.com</a></p>
+
+<h2>Thanks</h2>
+
+<p>Thanks to Manas for their awesome work on <a href="https://github.com/manastech/frank" target="_blank">Frank</a>.</p>
+</div>
+</body>
+</html>

--- a/doc/js/doc.js
+++ b/doc/js/doc.js
@@ -1,0 +1,89 @@
+document.addEventListener('DOMContentLoaded', function() {
+  var sessionStorage = window.sessionStorage;
+  if(!sessionStorage) {
+    sessionStorage = {
+      setItem: function() {},
+      getItem: function() {},
+      removeItem: function() {}
+    };
+  }
+
+  var repositoryName = document.getElementById('repository-name').getAttribute('content');
+  var typesList = document.getElementById('types-list');
+  var searchInput = document.getElementById('search-input');
+  var parents = document.querySelectorAll('#types-list li.parent');
+
+  for(var i = 0; i < parents.length; i++) {
+    var _parent = parents[i];
+    _parent.addEventListener('click', function(e) {
+      e.stopPropagation();
+
+      if(e.target.tagName.toLowerCase() == 'li') {
+        if(e.target.className.match(/open/)) {
+          sessionStorage.removeItem(e.target.getAttribute('data-id'));
+          e.target.className = e.target.className.replace(/ +open/g, '');
+        } else {
+          sessionStorage.setItem(e.target.getAttribute('data-id'), '1');
+          if(e.target.className.indexOf('open') == -1) {
+            e.target.className += ' open';
+          }
+        }
+      }
+    });
+
+    if(sessionStorage.getItem(_parent.getAttribute('data-id')) == '1') {
+      _parent.className += ' open';
+    }
+  };
+
+  var childMatch = function(type, regexp){
+    var types = type.querySelectorAll("ul li");
+    for (var j = 0; j < types.length; j ++) {
+      var t = types[j];
+      if(regexp.exec(t.getAttribute('data-name'))){ return true; };
+    };
+    return false;
+  };
+
+  var searchTimeout;
+  searchInput.addEventListener('keyup', function() {
+    clearTimeout(searchTimeout);
+    searchTimeout = setTimeout(function() {
+      var text = searchInput.value;
+      var types = document.querySelectorAll('#types-list li');
+      var words = text.toLowerCase().split(/\s+/).filter(function(word) {
+        return word.length > 0;
+      });
+      var regexp = new RegExp(words.join('|'));
+
+      for(var i = 0; i < types.length; i++) {
+        var type = types[i];
+        if(words.length == 0 || regexp.exec(type.getAttribute('data-name')) || childMatch(type, regexp)) {
+          type.className = type.className.replace(/ +hide/g, '');
+          var is_parent     =   new RegExp("parent").exec(type.className);
+          var is_not_opened = !(new RegExp("open").exec(type.className));
+          if(childMatch(type,regexp) && is_parent && is_not_opened){
+            type.className += " open";
+          };
+        } else {
+          if(type.className.indexOf('hide') == -1) {
+            type.className += ' hide';
+          };
+        };
+        if(words.length == 0){
+          type.className = type.className.replace(/ +open/g, '');
+        };
+      }
+    }, 200);
+  });
+
+  typesList.onscroll = function() {
+    var y = typesList.scrollTop;
+    sessionStorage.setItem(repositoryName + '::types-list:scrollTop', y);
+  };
+
+  var initialY = parseInt(sessionStorage.getItem(repositoryName + '::types-list:scrollTop') + "", 10);
+  if(initialY > 0) {
+    typesList.scrollTop = initialY;
+  }
+});

--- a/doc/toplevel.html
+++ b/doc/toplevel.html
@@ -1,0 +1,1186 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta id="repository-name" content="github.com/sdogruyol/kemal">
+  <link href="css/style.css" rel="stylesheet" type="text/css" />
+  <script type="text/javascript" src="js/doc.js"></script>
+  <title>Top Level Namespace - github.com/sdogruyol/kemal</title>
+</head>
+<body>
+
+<div id="types-list">
+  <div id="search-box">
+    <input type="search" id="search-input" placeholder="Search...">
+  </div>
+
+  <ul>
+    <li><a href="index.html">README</a></li>
+  </ul>
+
+  <ul>
+  
+  <li class=" current" data-id="github.com/sdogruyol/kemal/toplevel" data-name="top level namespace">
+      <a href="toplevel.html">Top Level Namespace</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal" data-name="kemal">
+      <a href="Kemal.html">Kemal</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/AllParamTypes" data-name="kemal::allparamtypes">
+      <a href="Kemal/AllParamTypes.html">AllParamTypes</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/BaseLogHandler" data-name="kemal::baseloghandler">
+      <a href="Kemal/BaseLogHandler.html">BaseLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CLI" data-name="kemal::cli">
+      <a href="Kemal/CLI.html">CLI</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonExceptionHandler" data-name="kemal::commonexceptionhandler">
+      <a href="Kemal/CommonExceptionHandler.html">CommonExceptionHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/CommonLogHandler" data-name="kemal::commonloghandler">
+      <a href="Kemal/CommonLogHandler.html">CommonLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Config" data-name="kemal::config">
+      <a href="Kemal/Config.html">Config</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions" data-name="kemal::exceptions">
+      <a href="Kemal/Exceptions.html">Exceptions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/CustomException" data-name="kemal::exceptions::customexception">
+      <a href="Kemal/Exceptions/CustomException.html">CustomException</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Exceptions/RouteNotFound" data-name="kemal::exceptions::routenotfound">
+      <a href="Kemal/Exceptions/RouteNotFound.html">RouteNotFound</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/InitHandler" data-name="kemal::inithandler">
+      <a href="Kemal/InitHandler.html">InitHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Middleware" data-name="kemal::middleware">
+      <a href="Kemal/Middleware.html">Middleware</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Block" data-name="kemal::middleware::block">
+      <a href="Kemal/Middleware/Block.html">Block</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/CSRF" data-name="kemal::middleware::csrf">
+      <a href="Kemal/Middleware/CSRF.html">CSRF</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/Filter" data-name="kemal::middleware::filter">
+      <a href="Kemal/Middleware/Filter.html">Filter</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/HTTPBasicAuth" data-name="kemal::middleware::httpbasicauth">
+      <a href="Kemal/Middleware/HTTPBasicAuth.html">HTTPBasicAuth</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Middleware/SSL" data-name="kemal::middleware::ssl">
+      <a href="Kemal/Middleware/SSL.html">SSL</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/NullLogHandler" data-name="kemal::nullloghandler">
+      <a href="Kemal/NullLogHandler.html">NullLogHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/ParamParser" data-name="kemal::paramparser">
+      <a href="Kemal/ParamParser.html">ParamParser</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Route" data-name="kemal::route">
+      <a href="Kemal/Route.html">Route</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/RouteHandler" data-name="kemal::routehandler">
+      <a href="Kemal/RouteHandler.html">RouteHandler</a>
+      
+    </li>
+  
+  <li class="parent " data-id="github.com/sdogruyol/kemal/Kemal/Sessions" data-name="kemal::sessions">
+      <a href="Kemal/Sessions.html">Sessions</a>
+      
+        <ul>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/Session" data-name="kemal::sessions::session">
+      <a href="Kemal/Sessions/Session.html">Session</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/Sessions/SessionTypes" data-name="kemal::sessions::sessiontypes">
+      <a href="Kemal/Sessions/SessionTypes.html">SessionTypes</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/StaticFileHandler" data-name="kemal::staticfilehandler">
+      <a href="Kemal/StaticFileHandler.html">StaticFileHandler</a>
+      
+    </li>
+  
+  <li class=" " data-id="github.com/sdogruyol/kemal/Kemal/WebSocketHandler" data-name="kemal::websockethandler">
+      <a href="Kemal/WebSocketHandler.html">WebSocketHandler</a>
+      
+    </li>
+  
+</ul>
+
+      
+    </li>
+  
+</ul>
+
+</div>
+
+<div id="main-content">
+<h1 class="type-name">
+
+  Top Level Namespace
+
+</h1>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <h2>Defined in:</h2>
+  
+
+
+
+  
+    <h2>Constant Summary</h2>
+  
+  <dl>
+    
+      <dt class="entry-const" id="ALL_METHODS">
+        <strong>ALL_METHODS</strong> = <code>[<span class="s">&quot;get&quot;</span>, <span class="s">&quot;post&quot;</span>, <span class="s">&quot;put&quot;</span>, <span class="s">&quot;patch&quot;</span>, <span class="s">&quot;delete&quot;</span>, <span class="s">&quot;all&quot;</span>] <span class="k">of</span> <span class="t">::</span><span class="t">String</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="CONTENT_FOR_BLOCKS">
+        <strong>CONTENT_FOR_BLOCKS</strong> = <code><span class="t">Hash</span>(<span class="t">String</span>, <span class="t">Tuple</span>(<span class="t">String</span>, <span class="t">Proc</span>(<span class="t">String</span>))).<span class="k">new</span></code>
+      </dt>
+      
+    
+      <dt class="entry-const" id="HTTP_METHODS">
+        <strong>HTTP_METHODS</strong> = <code>[<span class="s">&quot;get&quot;</span>, <span class="s">&quot;post&quot;</span>, <span class="s">&quot;put&quot;</span>, <span class="s">&quot;patch&quot;</span>, <span class="s">&quot;delete&quot;</span>, <span class="s">&quot;options&quot;</span>] <span class="k">of</span> <span class="t">::</span><span class="t">String</span></code>
+      </dt>
+      
+      <dd class="entry-const-doc">
+        <p>Kemal DSL is defined here and it's baked into global scope.
+The DSL currently consists of HTTP verbs(get post put patch delete options),
+WebSocket(ws) and custom error handler(error).</p>
+      </dd>
+      
+    
+  </dl>
+
+
+
+  <h2>Method Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#add_handler%28handler%29-class-method" class="signature"><strong>add_handler</strong>(handler)</a>
+        
+          <div class="summary"><p>Adds given HTTP::Handler+ to handlers.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#after_all%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>after_all</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#after_delete%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>after_delete</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#after_get%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>after_get</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#after_patch%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>after_patch</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#after_post%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>after_post</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#after_put%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>after_put</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#basic_auth%28username%2Cpassword%29-class-method" class="signature"><strong>basic_auth</strong>(username, password)</a>
+        
+          <div class="summary"><p>Uses Kemal::Middleware::HTTPBasicAuth to easily add HTTP Basic Auth support.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#before_all%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>before_all</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#before_delete%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>before_delete</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#before_get%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>before_get</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#before_patch%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>before_patch</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#before_post%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>before_post</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#before_put%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>before_put</strong>(path = <span class="s">&quot;*&quot;</span>, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#delete%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>delete</strong>(path, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#error%28status_code%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>error</strong>(status_code, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#get%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>get</strong>(path, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#gzip%28status%3ABool%3Dfalse%29-class-method" class="signature"><strong>gzip</strong>(status : Bool = <span class="n">false</span>)</a>
+        
+          <div class="summary"><p>Configures an <code><a href="HTTP/Server.html">HTTP::Server</a>::Response</code> to compress the response output, either using gzip or deflate, depending on the <code>Accept-Encoding</code> request header.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#headers%28env%2Cadditional_headers%29-class-method" class="signature"><strong>headers</strong>(env, additional_headers)</a>
+        
+          <div class="summary"><p>Helper for easily modifying response headers.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#log%28message%29-class-method" class="signature"><strong>log</strong>(message)</a>
+        
+          <div class="summary"><p>Logs to output stream.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#logger%28logger%29-class-method" class="signature"><strong>logger</strong>(logger)</a>
+        
+          <div class="summary"><p>Replaces Kemal::CommonLogHandler with a custom logger.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#logging%28status%29-class-method" class="signature"><strong>logging</strong>(status)</a>
+        
+          <div class="summary"><p>Enables / Disables logging</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#options%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>options</strong>(path, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#patch%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>patch</strong>(path, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#post%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>post</strong>(path, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#public_folder%28path%29-class-method" class="signature"><strong>public_folder</strong>(path)</a>
+        
+          <div class="summary"><p>Sets public folder from which the static assets will be served.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#put%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method" class="signature"><strong>put</strong>(path, &block : HTTP::Server::Context -> _)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#render_404-class-method" class="signature"><strong>render_404</strong></a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#render_500%28context%2Cbacktrace%2Cverbosity%29-class-method" class="signature"><strong>render_500</strong>(context, backtrace, verbosity)</a>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#send_file%28env%2Cpath%3AString%2Cmime_type%3AString%7CNil%3Dnil%29-class-method" class="signature"><strong>send_file</strong>(env, path : String, mime_type : String | Nil = <span class="n">nil</span>)</a>
+        
+          <div class="summary"><p>Send a file with given path and default <code>application/octet-stream</code> mime_type.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#send_file%28env%2Cdata%3ASlice%28UInt8%29%2Cmime_type%3AString%7CNil%3Dnil%29-class-method" class="signature"><strong>send_file</strong>(env, data : Slice(UInt8), mime_type : String | Nil = <span class="n">nil</span>)</a>
+        
+          <div class="summary"><p>Send a file with given data and default <code>application/octet-stream</code> mime_type.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#serve_static%28status%3ABool%7CHash%29-class-method" class="signature"><strong>serve_static</strong>(status : Bool | Hash)</a>
+        
+          <div class="summary"><p>Enables / Disables static file serving.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#ws%28path%2C%26block%3AHTTP%3A%3AWebSocket%2CHTTP%3A%3AServer%3A%3AContext-%3EVoid%29-class-method" class="signature"><strong>ws</strong>(path, &block : HTTP::WebSocket, HTTP::Server::Context -> Void)</a>
+        
+      </li>
+    
+  </ul>
+
+
+
+
+
+  <h2>Macro Summary</h2>
+  <ul class="list-summary">
+    
+      <li class="entry-summary">
+        <a href="#content_for%28key%2Cfile%3D__FILE__%29-macro" class="signature"><strong>content_for</strong>(key, file = __FILE__)</a>
+        
+          <div class="summary"><p>&lt;tt>content_for&lt;/tt> is a set of helpers that allows you to capture blocks inside views to be rendered later during the request.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#render%28filename%29-macro" class="signature"><strong>render</strong>(filename)</a>
+        
+          <div class="summary"><p>Render view with the given filename.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#render%28filename%2Clayout%29-macro" class="signature"><strong>render</strong>(filename, layout)</a>
+        
+          <div class="summary"><p>Render view with a layout as the superview.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#return_with%28env%2Cstatus_code%3D200%2Cresponse%3D%22%22%29-macro" class="signature"><strong>return_with</strong>(env, status_code = 200, response = "")</a>
+        
+          <div class="summary"><p>Halt execution with the current context.</p></div>
+        
+      </li>
+    
+      <li class="entry-summary">
+        <a href="#yield_content%28key%29-macro" class="signature"><strong>yield_content</strong>(key)</a>
+        
+          <div class="summary"><p>Yields content for the given key if a content_for block exists for that key.</p></div>
+        
+      </li>
+    
+  </ul>
+
+
+
+<div class="methods-inherited">
+  
+</div>
+
+
+  <h2>Method Detail</h2>
+  
+    <div class="entry-detail" id="add_handler&#40;handler&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>add_handler</strong>(handler)
+
+        <a class="method-permalink" href="#add_handler%28handler%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Adds given HTTP::Handler+ to handlers.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L2" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="after_all&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>after_all</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#after_all%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="after_delete&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>after_delete</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#after_delete%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="after_get&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>after_get</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#after_get%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="after_patch&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>after_patch</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#after_patch%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="after_post&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>after_post</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#after_post%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="after_put&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>after_put</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#after_put%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="basic_auth&#40;username,password&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>basic_auth</strong>(username, password)
+
+        <a class="method-permalink" href="#basic_auth%28username%2Cpassword%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Uses Kemal::Middleware::HTTPBasicAuth to easily add HTTP Basic Auth support.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L7" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="before_all&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>before_all</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#before_all%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="before_delete&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>before_delete</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#before_delete%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="before_get&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>before_get</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#before_get%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="before_patch&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>before_patch</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#before_patch%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="before_post&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>before_post</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#before_post%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="before_put&#40;path&#61;&amp;quot;*&amp;quot;,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>before_put</strong>(path = <span class="s">&quot;*&quot;</span>, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#before_put%28path%3D%26quot%3B%2A%26quot%3B%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/middleware/filters.cr#L91" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="delete&#40;path,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>delete</strong>(path, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#delete%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/dsl.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="error&#40;status_code,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>error</strong>(status_code, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#error%28status_code%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/dsl.cr#L16" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="get&#40;path,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>get</strong>(path, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#get%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/dsl.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="gzip&#40;status:Bool&#61;false&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>gzip</strong>(status : Bool = <span class="n">false</span>)
+
+        <a class="method-permalink" href="#gzip%28status%3ABool%3Dfalse%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Configures an <code><a href="HTTP/Server.html">HTTP::Server</a>::Response</code> to compress the response
+output, either using gzip or deflate, depending on the <code>Accept-Encoding</code> request header.
+It's disabled by default.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L78" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="headers&#40;env,additional_headers&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>headers</strong>(env, additional_headers)
+
+        <a class="method-permalink" href="#headers%28env%2Cadditional_headers%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Helper for easily modifying response headers.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L40" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="log&#40;message&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>log</strong>(message)
+
+        <a class="method-permalink" href="#log%28message%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Logs to output stream. STDOUT is the default stream.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L19" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="logger&#40;logger&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>logger</strong>(logger)
+
+        <a class="method-permalink" href="#logger%28logger%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Replaces Kemal::CommonLogHandler with a custom logger.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L29" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="logging&#40;status&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>logging</strong>(status)
+
+        <a class="method-permalink" href="#logging%28status%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Enables / Disables logging</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L24" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="options&#40;path,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>options</strong>(path, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#options%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/dsl.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="patch&#40;path,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>patch</strong>(path, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#patch%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/dsl.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="post&#40;path,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>post</strong>(path, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#post%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/dsl.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="public_folder&#40;path&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>public_folder</strong>(path)
+
+        <a class="method-permalink" href="#public_folder%28path%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Sets public folder from which the static assets will be served.
+By default this is <code>/public</code> not <code>src/public</code>.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L14" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="put&#40;path,&amp;block:HTTP::Server::Context-&gt;_&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>put</strong>(path, &block : <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> _)
+
+        <a class="method-permalink" href="#put%28path%2C%26block%3AHTTP%3A%3AServer%3A%3AContext-%3E_%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/dsl.cr#L6" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="render_404-class-method">
+      <div class="signature">
+        
+        def <strong>render_404</strong>
+
+        <a class="method-permalink" href="#render_404-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/templates.cr#L4" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="render_500&#40;context,backtrace,verbosity&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>render_500</strong>(context, backtrace, verbosity)
+
+        <a class="method-permalink" href="#render_500%28context%2Cbacktrace%2Cverbosity%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/templates.cr#L23" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="send_file&#40;env,path:String,mime_type:String|Nil&#61;nil&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>send_file</strong>(env, path : String, mime_type : String | Nil = <span class="n">nil</span>)
+
+        <a class="method-permalink" href="#send_file%28env%2Cpath%3AString%2Cmime_type%3AString%7CNil%3Dnil%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Send a file with given path and default <code>application/octet-stream</code> mime_type.</p>
+
+<p>send_file env, "./path/to/file"</p>
+
+<p>Optionally you can override the mime_type</p>
+
+<p>send_file env, "./path/to/file", "image/jpeg"</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L51" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="send_file&#40;env,data:Slice&#40;UInt8&#41;,mime_type:String|Nil&#61;nil&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>send_file</strong>(env, data : Slice(UInt8), mime_type : String | Nil = <span class="n">nil</span>)
+
+        <a class="method-permalink" href="#send_file%28env%2Cdata%3ASlice%28UInt8%29%2Cmime_type%3AString%7CNil%3Dnil%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Send a file with given data and default <code>application/octet-stream</code> mime_type.</p>
+
+<p>send_file env, data_slice</p>
+
+<p>Optionally you can override the mime_type</p>
+
+<p>send_file env, data_slice, "image/jpeg"</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L68" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="serve_static&#40;status:Bool|Hash&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>serve_static</strong>(status : Bool | Hash)
+
+        <a class="method-permalink" href="#serve_static%28status%3ABool%7CHash%29-class-method">#</a>
+      </div>
+      
+        <div class="doc"><p>Enables / Disables static file serving.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/helpers.cr#L35" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="ws&#40;path,&amp;block:HTTP::WebSocket,HTTP::Server::Context-&gt;Void&#41;-class-method">
+      <div class="signature">
+        
+        def <strong>ws</strong>(path, &block : HTTP::WebSocket, <a href="HTTP/Server/Context.html">HTTP::Server::Context</a> -> Void)
+
+        <a class="method-permalink" href="#ws%28path%2C%26block%3AHTTP%3A%3AWebSocket%2CHTTP%3A%3AServer%3A%3AContext-%3EVoid%29-class-method">#</a>
+      </div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/dsl.cr#L12" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+
+
+
+  <h2>Macro Detail</h2>
+  
+    <div class="entry-detail" id="content_for&#40;key,file&#61;__FILE__&#41;-macro">
+      <div class="signature">
+        
+        macro <strong>content_for</strong>(key, file = __FILE__)
+
+        <a class="method-permalink" href="#content_for%28key%2Cfile%3D__FILE__%29-macro">#</a>
+      </div>
+      
+        <div class="doc"><p>&lt;tt>content_for&lt;/tt> is a set of helpers that allows you to capture
+blocks inside views to be rendered later during the request. The most
+common use is to populate different parts of your layout from your view.</p>
+
+<p>The currently supported engines are: ecr and slang.</p>
+
+<p>== Usage</p>
+
+<p>You call +content_for+, generally from a view, to capture a block of markup
+giving it an identifier:</p>
+
+<pre><code><span class="c"># index.ecr</span>
+<span class="o"><</span><span class="o">%</span> content_for <span class="s">&quot;some_key&quot;</span> <span class="k">do</span> <span class="o">%</span><span class="o">></span>
+  <span class="o"><</span>chunk <span class="k">of</span><span class="o">=</span><span class="s">&quot;html&quot;</span><span class="o">></span>...<span class="o"><</span><span class="s">/chunk&gt;
+&lt;&#37; end &#37;&gt;</code></pre>
+
+<p>Then, you call +yield_content+ with that identifier, generally from a
+layout, to render the captured block:</p>
+
+<pre><code><span class="c"># layout.ecr</span>
+<span class="o"><</span>%= yield_content <span class="s">&quot;some_key&quot;</span> <span class="o">%</span><span class="o">></span></code></pre>
+
+<p>== And How Is This Useful?</p>
+
+<p>For example, some of your views might need a few javascript tags and
+stylesheets, but you don't want to force this files in all your pages.
+Then you can put &lt;tt>&lt;%= yield_content :scripts_and_styles %>&lt;/tt> on your
+layout, inside the &lt;head> tag, and each view can call &lt;tt>content_for&lt;/tt>
+setting the appropriate set of tags that should be added to the layout.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/macros.cr#L34" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="render&#40;filename&#41;-macro">
+      <div class="signature">
+        
+        macro <strong>render</strong>(filename)
+
+        <a class="method-permalink" href="#render%28filename%29-macro">#</a>
+      </div>
+      
+        <div class="doc"><p>Render view with the given filename.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/macros.cr#L65" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="render&#40;filename,layout&#41;-macro">
+      <div class="signature">
+        
+        macro <strong>render</strong>(filename, layout)
+
+        <a class="method-permalink" href="#render%28filename%2Clayout%29-macro">#</a>
+      </div>
+      
+        <div class="doc"><p>Render view with a layout as the superview.</p>
+
+<p>render "src/views/index.ecr", "src/views/layout.ecr"</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/macros.cr#L58" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="return_with&#40;env,status_code&#61;200,response&#61;&quot;&quot;&#41;-macro">
+      <div class="signature">
+        
+        macro <strong>return_with</strong>(env, status_code = 200, response = "")
+
+        <a class="method-permalink" href="#return_with%28env%2Cstatus_code%3D200%2Cresponse%3D%22%22%29-macro">#</a>
+      </div>
+      
+        <div class="doc"><p>Halt execution with the current context.
+Returns 200 and an empty response by default.</p>
+
+<p>return_with env, status_code: 403, response: "Forbidden"</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/macros.cr#L73" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+    <div class="entry-detail" id="yield_content&#40;key&#41;-macro">
+      <div class="signature">
+        
+        macro <strong>yield_content</strong>(key)
+
+        <a class="method-permalink" href="#yield_content%28key%29-macro">#</a>
+      </div>
+      
+        <div class="doc"><p>Yields content for the given key if a content_for block exists for that key.</p></div>
+      
+      <br/>
+      <div>
+        
+          [<a href="https://github.com/sdogruyol/kemal/blob/ad9790b9d844c66dca4053272dba91b9b7b2dfb3/src/kemal/helpers/macros.cr#L46" target="_blank">View source</a>]
+        
+      </div>
+    </div>
+  
+
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
As suggested by #209, this PR adds:

* API documentation generated by ```crystal doc```
* Rakefile with task ```rake docs``` that rebuilds the doc/ folder
* The link to docs on navbar.