### PR TITLE
Add new line between logo and title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <img src="https://avatars3.githubusercontent.com/u/15321198?v=3&s=200" width="100" height="100" />
+
 # Kemal [![Build Status](https://travis-ci.org/sdogruyol/kemal.svg?branch=master)](https://travis-ci.org/sdogruyol/kemal)
 
 [![Join the chat at https://gitter.im/sdogruyol/kemal](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sdogruyol/kemal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Small fix for markdown rendering in crystal-docs.org