### PR TITLE
Improve Multipart upload information

### DIFF
--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -79,19 +79,32 @@ def gzip(status : Bool = false)
   add_handler HTTP::DeflateHandler.new if status
 end
 
-# Parses a multipart/form-data request. This is really useful for file uploads.
+# nodoc:
+struct UploadFile
+  getter field : String
+  getter data : IO::Delimited
+  getter meta : HTTP::FormData::FileMetadata
+  getter headers : HTTP::Headers
+
+  def initialize(@field, @data, @meta, @headers)
+  end
+end
+
+# Parses a multipart/form-data request. Yields an `UploadFile` object with `field`, `data`, `meta`, `headers` fields.
 # Consider the example below taking two image uploads as image1, image2. To get the relevant data
-# for each field you can use simple `if/switch` conditional.
+# for each file you can use simple `if/switch` conditionals.
 #
 #   post "/upload" do |env|
-#     parse_multipart(env) do |field, data|
-#       image1 = data if field == "image1"
-#       image2 = data if field == "image2"
+#     parse_multipart(env) do |f|
+#       image1 = f.data if f.field == "image1"
+#       image2 = f.data if f.field == "image2"
+#       puts f.meta
+#       puts f.headers
 #       "Upload complete"
 #     end
 #   end
 def parse_multipart(env)
-  HTTP::FormData.parse(env.request) do |field, data|
-    yield field, data
+  HTTP::FormData.parse(env.request) do |field, data, meta, headers|
+    yield UploadFile.new field, data, meta, headers
   end
 end


### PR DESCRIPTION
Thanks @miguelm on https://github.com/sdogruyol/kemal/pull/223.

Instead of just yielding `|field, data|` on `parse_multipart` we are going to yield a `UploadFile` object which has `field`,`data`, `meta`, `headers` properties.

```crystal
post "/upload" do |env|
  parse_multipart(env) do |f|
    image1 = f.data if f.field == "image1"
    image2 = f.data if f.field == "image2"
    puts f.meta
    puts f.headers
    "Upload complete"
  end
end
```