### PR TITLE
Add only_routes and exclude_routes macros for middlewares

### DIFF
--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -5,7 +5,7 @@ HTTP_METHODS = %w(get post put patch delete options)
 
 {% for method in HTTP_METHODS %}
   def {{method.id}}(path, &block : HTTP::Server::Context -> _)
-   Kemal::RouteHandler::INSTANCE.add_route({{method}}.upcase, path, &block)
+    Kemal::RouteHandler::INSTANCE.add_route({{method}}.upcase, path, &block)
   end
 {% end %}
 

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -49,4 +49,38 @@ module Kemal
       @tree.add node, route
     end
   end
+
+  # Extend HTTP::Handler so that certain macros are scoped to HTTP::Handler or
+  # inheriting classes, and not part of the global scope
+  class HTTP::Handler
+    private def to_path_regex(path)
+      path = ("^" + path + "(\/)?$").split("**")
+      path = path.map { |p| p.gsub(/\*/, "[\\w\\d~]*") }
+      Regex.new path.join("[\\w\\d\\/~]*")
+    end
+
+    # Checks if two routes match.
+    # The second path may or may not have a single (*) or double wildcard (**)
+    private def paths_match?(actual_path, dynamic_path)
+      return true if (actual_path === dynamic_path && !dynamic_path.includes? "*")
+      actual_path = actual_path + "/" unless actual_path.ends_with?("/")
+      actual_path =~ to_path_regex dynamic_path
+    end
+
+    # Will only run rest of middleware if the current
+    # route matches one of the given routes
+    macro only_routes(context, routes)
+      return call_next {{context}} unless {{routes}}.any? do |route|
+        paths_match? {{context}}.request.path, route
+      end
+    end
+
+    # Will only run rest of middleware if the current
+    # route does NOT match one of the given routes
+    macro exclude_routes(context, routes)
+      return call_next {{context}} if {{routes}}.any? do |route|
+        paths_match? {{context}}.request.path, route
+      end
+    end
+  end
 end


### PR DESCRIPTION
I wasn't seeing a way to tell middleware to run (or not to run) conditionally based on the path.

I propose to add `only_routes` and `exclude_routes` that can run _anywhere_ in the middleware (but preferably at the top) to conditionally exit the middleware or to continue.

Examples:

```ruby
# only_routes macro
class MyCustomHandler < HTTP::Handler
  def call(context)
    only_routes context, ["/admin/**", "/user"]
    # if the request path DOES NOT match one of given paths in the previous line then none
    # of the rest of the middleware will be ran

    puts "Doing some custom stuff here"
    call_next context
  end
end

# exclude_routes macro
class MyCustomHandler < HTTP::Handler
  def call(context)
    exclude_routes context, ["/", "/about"]
    # if the request path DOES match one of given paths in the previous line then none
    # of the rest of the middleware will be ran
    
    puts "Doing some custom stuff here"
    call_next context
  end
end
```