### PR TITLE
Decodes url parameters

### DIFF
--- a/spec/param_parser_spec.cr
+++ b/spec/param_parser_spec.cr
@@ -33,6 +33,23 @@ describe "ParamParser" do
     url_params["hasan"].should eq "cemal"
   end
 
+  it "decodes url params" do
+    kemal = Kemal::RouteHandler::INSTANCE
+    kemal.add_route "POST", "/hello/:email/:money/:spanish" do |env|
+      email = env.params.url["email"]
+      money = env.params.url["money"]
+      spanish = env.params.url["spanish"]
+      "Hello, #{email}. You have #{money}. The spanish word of the day is #{spanish}."
+    end
+    request = HTTP::Request.new("POST", "/hello/sam%2Bspec%40gmail.com/%2419.99/a%C3%B1o")
+    # Radix tree MUST be run to parse url params.
+    io_with_context = create_request_and_return_io(kemal, request)
+    url_params = Kemal::ParamParser.new(request).url
+    url_params["email"].should eq "sam+spec@gmail.com"
+    url_params["money"].should eq "$19.99"
+    url_params["spanish"].should eq "año"
+  end
+
   it "parses request body" do
     route = Route.new "POST", "/" do |env|
       name = env.params.query["name"]

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -5,7 +5,7 @@ HTTP_METHODS = %w(get post put patch delete options)
 
 {% for method in HTTP_METHODS %}
   def {{method.id}}(path, &block : HTTP::Server::Context -> _)
-   Kemal::RouteHandler::INSTANCE.add_route({{method}}.upcase, path, &block)
+    Kemal::RouteHandler::INSTANCE.add_route({{method}}.upcase, path, &block)
   end
 {% end %}
 

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -21,6 +21,10 @@ module Kemal
       @json_parsed = false
     end
 
+    private def decode_url_param(value : String)
+      value.size == 0 ? value : HTTP::Params.parse(value).first[0]?
+    end
+
     {% for method in %w(url query body json) %}
     def {{method.id}}
       # check memoization
@@ -45,7 +49,7 @@ module Kemal
     def parse_url
       if params = @request.url_params
         params.each do |key, value|
-          @url[key.as(String)] = value.as(String)
+          @url[key.as(String)] = decode_url_param(value).as(String)
         end
       end
     end


### PR DESCRIPTION
I found a little url parameter issue. In some other comparable non-crystal web frameworks, url parameters are decoded.

Here is an example comparing the response of ruby's sinatra with kemal.

### Sinatra  
```ruby
# GET [HOST]/user/sam%2Btest%40gmail.com

get "/user/:email" do
  params["email"]
end

# Response body => sam+test@gmail.com
```

### Kemal  
```ruby
# GET [HOST]/user/sam%2Btest%40gmail.com

get "/user/:email" do |env|
  env.params.url["email"]
end

# Response body => sam%2Btest%40gmail.com
```

Sinatra correctly decodes the url parameters. I have not used Sinatra in production, but I have a good amount of experience with the Node.js Express framework and I know that the url parameters are also decoded with Express.

Keep up the good work! 👍