### PR TITLE
Middleware ordering

### DIFF
--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -32,31 +32,31 @@ describe "Context" do
     client_response.headers["Accept-Language"].should eq "tr"
   end
 
-  it "can store variables" do
-    before_get "/" do |env|
-      env.set "before_get", "Kemal"
-      env.set "before_get_int", 123
-      env.set "before_get_float", 3.5
-    end
+  # it "can store variables" do
+  #   before_get "/" do |env|
+  #     env.set "before_get", "Kemal"
+  #     env.set "before_get_int", 123
+  #     env.set "before_get_float", 3.5
+  #   end
 
-    get "/" do |env|
-      env.set "key", "value"
-      {
-        key:              env.get("key"),
-        before_get:       env.get("before_get"),
-        before_get_int:   env.get("before_get_int"),
-        before_get_float: env.get("before_get_float"),
-      }
-    end
-    request = HTTP::Request.new("GET", "/")
-    io = MemoryIO.new
-    response = HTTP::Server::Response.new(io)
-    context = HTTP::Server::Context.new(request, response)
-    Kemal::Middleware::Filter::INSTANCE.call(context)
-    Kemal::RouteHandler::INSTANCE.call(context)
-    context.store["key"].should eq "value"
-    context.store["before_get"].should eq "Kemal"
-    context.store["before_get_int"].should eq 123
-    context.store["before_get_float"].should eq 3.5
-  end
+  #   get "/" do |env|
+  #     env.set "key", "value"
+  #     {
+  #       key:              env.get("key"),
+  #       before_get:       env.get("before_get"),
+  #       before_get_int:   env.get("before_get_int"),
+  #       before_get_float: env.get("before_get_float"),
+  #     }
+  #   end
+  #   request = HTTP::Request.new("GET", "/")
+  #   io = MemoryIO.new
+  #   response = HTTP::Server::Response.new(io)
+  #   context = HTTP::Server::Context.new(request, response)
+  #   Kemal::Middleware::Filter::INSTANCE.call(context)
+  #   Kemal::RouteHandler::INSTANCE.call(context)
+  #   context.store["key"].should eq "value"
+  #   context.store["before_get"].should eq "Kemal"
+  #   context.store["before_get_int"].should eq 123
+  #   context.store["before_get_float"].should eq 3.5
+  # end
 end

--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -32,31 +32,31 @@ describe "Context" do
     client_response.headers["Accept-Language"].should eq "tr"
   end
 
-  # it "can store variables" do
-  #   before_get "/" do |env|
-  #     env.set "before_get", "Kemal"
-  #     env.set "before_get_int", 123
-  #     env.set "before_get_float", 3.5
-  #   end
+  it "can store variables" do
+    before_get "/" do |env|
+      env.set "before_get", "Kemal"
+      env.set "before_get_int", 123
+      env.set "before_get_float", 3.5
+    end
 
-  #   get "/" do |env|
-  #     env.set "key", "value"
-  #     {
-  #       key:              env.get("key"),
-  #       before_get:       env.get("before_get"),
-  #       before_get_int:   env.get("before_get_int"),
-  #       before_get_float: env.get("before_get_float"),
-  #     }
-  #   end
-  #   request = HTTP::Request.new("GET", "/")
-  #   io = MemoryIO.new
-  #   response = HTTP::Server::Response.new(io)
-  #   context = HTTP::Server::Context.new(request, response)
-  #   Kemal::Middleware::Filter::INSTANCE.call(context)
-  #   Kemal::RouteHandler::INSTANCE.call(context)
-  #   context.store["key"].should eq "value"
-  #   context.store["before_get"].should eq "Kemal"
-  #   context.store["before_get_int"].should eq 123
-  #   context.store["before_get_float"].should eq 3.5
-  # end
+    get "/" do |env|
+      env.set "key", "value"
+      {
+        key:              env.get("key"),
+        before_get:       env.get("before_get"),
+        before_get_int:   env.get("before_get_int"),
+        before_get_float: env.get("before_get_float"),
+      }
+    end
+    request = HTTP::Request.new("GET", "/")
+    io = MemoryIO.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    Kemal::Middleware::Filter::INSTANCE.call(context)
+    Kemal::RouteHandler::INSTANCE.call(context)
+    context.store["key"].should eq "value"
+    context.store["before_get"].should eq "Kemal"
+    context.store["before_get_int"].should eq 123
+    context.store["before_get_float"].should eq 3.5
+  end
 end

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -10,12 +10,10 @@ end
 describe "Handler" do
   it "adds custom handler before before_*" do
     before_get "/" do |env|
-      puts "Next 1"
       env.response << " is"
     end
 
     before_get "/" do |env|
-      puts "Next 2"
       env.response << " so"
     end
 
@@ -27,11 +25,6 @@ describe "Handler" do
     get "/" do |env|
       " Great"
     end
-
-    Kemal.config.handlers.each do |h|
-      puts h.class
-    end
-
     request = HTTP::Request.new("GET", "/")
     client_response = call_request_on_app(request)
     client_response.status_code.should eq(200)

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -9,17 +9,14 @@ end
 
 describe "Handler" do
   it "adds custom handler before before_*" do
-    before_get "/" do |env|
+    filter_middleware = Kemal::Middleware::Filter.new
+    filter_middleware._add_route_filter("GET", "/", :before) do |env|
       env.response << " is"
     end
 
-    before_get "/" do |env|
+    filter_middleware._add_route_filter("GET", "/", :before) do |env|
       env.response << " so"
     end
-
-    before_all "/" do
-    end
-
     add_handler CustomTestHandler.new
 
     get "/" do |env|

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -19,6 +19,9 @@ describe "Handler" do
       env.response << " so"
     end
 
+    before_all "/" do
+    end
+
     add_handler CustomTestHandler.new
 
     get "/" do |env|

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -1,0 +1,37 @@
+require "./spec_helper"
+
+class CustomTestHandler < HTTP::Handler
+  def call(env)
+    env.response << "Kemal"
+    call_next env
+  end
+end
+
+describe "Handler" do
+  it "adds custom handler before before_*" do
+    before_get "/" do |env|
+      puts "Next 1"
+      env.response << " is"
+    end
+
+    before_get "/" do |env|
+      puts "Next 2"
+      env.response << " so"
+    end
+
+    add_handler CustomTestHandler.new
+
+    get "/" do |env|
+      " Great"
+    end
+
+    Kemal.config.handlers.each do |h|
+      puts h.class
+    end
+
+    request = HTTP::Request.new("GET", "/")
+    client_response = call_request_on_app(request)
+    client_response.status_code.should eq(200)
+    client_response.body.should eq("Kemal is so Great")
+  end
+end

--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -30,7 +30,7 @@ describe "Macros" do
     it "sets a custom logger" do
       config = Kemal::Config::INSTANCE
       logger CustomLogHandler.new
-      config.handlers.last.should be_a(CustomLogHandler)
+      config.handlers[4].should be_a(CustomLogHandler)
       config.logger.should be_a(CustomLogHandler)
     end
   end
@@ -77,7 +77,6 @@ describe "Macros" do
           "Content-Type"                => "text/plain",
         }
       end
-
       request = HTTP::Request.new("GET", "/headers")
       response = call_request_on_app(request)
       response.headers["Access-Control-Allow-Origin"].should eq("*")
@@ -126,11 +125,7 @@ describe "Macros" do
   describe "#gzip" do
     it "adds HTTP::DeflateHandler to handlers" do
       gzip true
-      Kemal.config.handlers.last.is_a?(HTTP::DeflateHandler).should eq true
-    end
-
-    it "doesn't add HTTP::DeflateHandler to handlers by default" do
-      Kemal.config.handlers.last.is_a?(HTTP::DeflateHandler).should eq false
+      Kemal.config.handlers[4].should be_a(HTTP::DeflateHandler)
     end
   end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -65,4 +65,5 @@ end
 Spec.after_each do
   Kemal.config.clear
   Kemal::RouteHandler::INSTANCE.tree = Radix::Tree(Route).new
+  Kemal::Middleware::Filter::INSTANCE.tree = Radix::Tree(Array(Kemal::Middleware::Block)).new
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -65,5 +65,4 @@ end
 Spec.after_each do
   Kemal.config.clear
   Kemal::RouteHandler::INSTANCE.tree = Radix::Tree(Route).new
-  Kemal::Middleware::Filter::INSTANCE.tree = Radix::Tree(Array(Kemal::Middleware::Block)).new
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -5,11 +5,9 @@ module Kemal
   #   Kemal.config
   #
   class Config
-    INSTANCE        = Config.new
-    HANDLERS        = [] of HTTP::Handler
-    CUSTOM_HANDLERS = [] of HTTP::Handler
-    FILTER_HANDLERS = [] of HTTP::Handler
-    ERROR_HANDLERS  = {} of Int32 => HTTP::Server::Context -> String
+    INSTANCE       = Config.new
+    HANDLERS       = [] of HTTP::Handler
+    ERROR_HANDLERS = {} of Int32 => HTTP::Server::Context -> String
     {% if flag?(:without_openssl) %}
     @ssl : Bool?
     {% else %}
@@ -53,8 +51,6 @@ module Kemal
       @custom_handler_position = 4
       @default_handlers_setup = false
       HANDLERS.clear
-      CUSTOM_HANDLERS.clear
-      FILTER_HANDLERS.clear
     end
 
     def handlers
@@ -62,18 +58,16 @@ module Kemal
     end
 
     def add_handler(handler : HTTP::Handler)
-      CUSTOM_HANDLERS << handler
-      setup_custom_handlers
+      HANDLERS.insert @custom_handler_position, handler
+      @custom_handler_position = @custom_handler_position + 1
     end
 
     def add_filter_handler(handler : HTTP::Handler)
-      FILTER_HANDLERS << handler
-      setup_filter_handlers
+      HANDLERS.insert HANDLERS.size - 1, handler
     end
 
     def add_ws_handler(handler : HTTP::WebSocketHandler)
-      CUSTOM_HANDLERS << handler
-      setup_custom_handlers
+      HANDLERS << handler
     end
 
     def error_handlers
@@ -88,14 +82,12 @@ module Kemal
     end
 
     def setup
-      unless @default_handlers_setup
+      unless @default_handlers_setup && @router_included
         setup_init_handler
         setup_log_handler
         setup_error_handler
         setup_static_file_handler
         @default_handlers_setup = true
-      end
-      unless @router_included
         @router_included = true
         HANDLERS.insert(HANDLERS.size, Kemal::RouteHandler::INSTANCE)
       end
@@ -123,19 +115,6 @@ module Kemal
 
     private def setup_static_file_handler
       HANDLERS.insert(3, Kemal::StaticFileHandler.new(@public_folder)) if @serve_static.is_a?(Hash)
-    end
-
-    private def setup_custom_handlers
-      CUSTOM_HANDLERS.each do |handler|
-        HANDLERS.insert @custom_handler_position, handler
-        @custom_handler_position = @custom_handler_position + 1
-      end
-    end
-
-    private def setup_filter_handlers
-      FILTER_HANDLERS.each do |handler|
-        HANDLERS.insert HANDLERS.size - 1, handler
-      end
     end
   end
 

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -58,15 +58,18 @@ module Kemal
     end
 
     def add_handler(handler : HTTP::Handler)
+      setup
       HANDLERS.insert @custom_handler_position, handler
       @custom_handler_position = @custom_handler_position + 1
     end
 
     def add_filter_handler(handler : HTTP::Handler)
+      setup
       HANDLERS.insert HANDLERS.size - 1, handler
     end
 
     def add_ws_handler(handler : HTTP::WebSocketHandler)
+      setup
       HANDLERS << handler
     end
 

--- a/src/kemal/middleware/filters.cr
+++ b/src/kemal/middleware/filters.cr
@@ -4,6 +4,8 @@ module Kemal::Middleware
   class Filter < HTTP::Handler
     INSTANCE = new
 
+    property tree
+
     # This middleware is lazily instantiated and added to the handlers as soon as a call to `after_X` or `before_X` is made.
     def initialize
       @tree = Radix::Tree(Array(Kemal::Middleware::Block)).new

--- a/src/kemal/middleware/filters.cr
+++ b/src/kemal/middleware/filters.cr
@@ -7,7 +7,7 @@ module Kemal::Middleware
     # This middleware is lazily instantiated and added to the handlers as soon as a call to `after_X` or `before_X` is made.
     def initialize
       @tree = Radix::Tree(Array(Kemal::Middleware::Block)).new
-      Kemal.config.add_handler(self)
+      Kemal.config.add_filter_handler(self)
     end
 
     # The call order of the filters is before_all -> before_x -> X -> after_x -> after_all

--- a/src/kemal/middleware/filters.cr
+++ b/src/kemal/middleware/filters.cr
@@ -4,8 +4,6 @@ module Kemal::Middleware
   class Filter < HTTP::Handler
     INSTANCE = new
 
-    property tree
-
     # This middleware is lazily instantiated and added to the handlers as soon as a call to `after_X` or `before_X` is made.
     def initialize
       @tree = Radix::Tree(Array(Kemal::Middleware::Block)).new

--- a/src/kemal/route.cr
+++ b/src/kemal/route.cr
@@ -8,7 +8,9 @@ module Kemal
     @method : String
 
     def initialize(@method, @path : String, &handler : HTTP::Server::Context -> _)
-      @handler = ->(context : HTTP::Server::Context) { handler.call(context).to_s }
+      @handler = ->(context : HTTP::Server::Context) do
+        handler.call(context).to_s
+      end
     end
   end
 end


### PR DESCRIPTION
This improves middleware ordering.

Middlewares should work as intended, before all before_* filters and routes.

```
Request -> Middleware -> Filter -> Route
```

This works but `crystal spec` fails with a weird issue.

```
crystal spec

F...........................................................................

Failures:

  1) Handler adds custom handler before before_*
     Failure/Error: client_response.body.should eq("Kemal is so Great")

       expected: "Kemal is so Great"
            got: "Kemal Great"

     # ./spec/handler_spec.cr:39
```

Meanwhile requiring the spec files with exact paths work.

```
crystal spec spec/handler_spec.cr spec/middleware/filters_spec.cr spec/middleware/csrf_spec.cr spec/middleware/http_basic_auth_spec.cr spec/common_exception_handler_spec.cr spec/common_log_handler_spec.cr spec/config_spec.cr spec/context_spec.cr spec/helpers_spec.cr spec/init_handler_spec.cr spec/param_parser_spec.cr spec/route_handler_spec.cr spec/route_spec.cr spec/session_spec.cr spec/static_file_handler.cr spec/view_spec.cr spec/websocket_handler_spec.cr

2016-10-27 17:33:59 +0300 200 GET / 76.0µs
..........................2016-10-27 17:33:59 +0300 200 GET / 12.0µs
.2016-10-27 17:33:59 +0300 200 GET / 10.0µs
.2016-10-27 17:33:59 +0300 200 GET / 26.0µs
................................................................

Finished in 13.8 milliseconds
92 examples, 0 failures, 0 errors, 0 pending
```
//cc @asterite 