### PR TITLE
Only / Exclude Paths in Middleware

### DIFF
--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -15,9 +15,6 @@ class OnlyHandler < Kemal::Handler
     env.response.print "Only"
     call_next env
   end
-
-  def write(message)
-  end
 end
 
 class ExcludeHandler < Kemal::Handler

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -1,8 +1,51 @@
 require "./spec_helper"
 
-class CustomTestHandler < HTTP::Handler
+class CustomTestHandler < Kemal::Handler
   def call(env)
     env.response << "Kemal"
+    call_next env
+  end
+end
+
+class OnlyHandler < Kemal::Handler
+  only ["/only"]
+
+  def call(env)
+    super && return(call_next(env))
+    env.response.print "Only"
+    call_next env
+  end
+
+  def write(message)
+  end
+end
+
+class ExcludeHandler < Kemal::Handler
+  exclude ["/exclude"]
+
+  def call(env)
+    super && return(call_next(env))
+    env.response.print "Exclude"
+    call_next env
+  end
+end
+
+class PostOnlyHandler < Kemal::Handler
+  only ["/only", "/route1", "/route2"]
+
+  def call(env)
+    super && return(call_next(env))
+    env.response.print "Only"
+    call_next env
+  end
+end
+
+class PostExcludeHandler < Kemal::Handler
+  exclude ["/exclude"], "POST"
+
+  def call(env)
+    super && return(call_next(env))
+    env.response.print "Exclude"
     call_next env
   end
 end
@@ -26,5 +69,58 @@ describe "Handler" do
     client_response = call_request_on_app(request)
     client_response.status_code.should eq(200)
     client_response.body.should eq("Kemal is so Great")
+  end
+
+  it "runs specified only_routes in middleware" do
+    get "/only" do |env|
+      "Get"
+    end
+    add_handler OnlyHandler.new
+    request = HTTP::Request.new("GET", "/only")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq "OnlyGet"
+  end
+
+  it "doesn't run specified exclude_routes in middleware" do
+    get "/" do |env|
+      "Get"
+    end
+    get "/exclude" do
+      "Exclude"
+    end
+    add_handler ExcludeHandler.new
+    request = HTTP::Request.new("GET", "/")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq "ExcludeGet"
+  end
+
+  it "runs specified only_routes with method in middleware" do
+    post "/only" do
+      "Post"
+    end
+    get "/only" do
+      "Get"
+    end
+    add_handler PostOnlyHandler.new
+    request = HTTP::Request.new("POST", "/only")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq "OnlyPost"
+  end
+
+  it "runs specified exclude_routes with method in middleware" do
+    post "/exclude" do
+      "Post"
+    end
+    post "/only" do
+      "Post"
+    end
+    add_handler PostOnlyHandler.new
+    request = HTTP::Request.new("POST", "/only")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq "OnlyPost"
+    add_handler PostExcludeHandler.new
+    request = HTTP::Request.new("POST", "/only")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq "OnlyExcludePost"
   end
 end

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -11,7 +11,7 @@ class OnlyHandler < Kemal::Handler
   only ["/only"]
 
   def call(env)
-    super && return(call_next(env))
+    return unless only_match?(env)
     env.response.print "Only"
     call_next env
   end
@@ -21,17 +21,17 @@ class ExcludeHandler < Kemal::Handler
   exclude ["/exclude"]
 
   def call(env)
-    super && return(call_next(env))
+    return unless exclude_match?(env)
     env.response.print "Exclude"
     call_next env
   end
 end
 
 class PostOnlyHandler < Kemal::Handler
-  only ["/only", "/route1", "/route2"]
+  only ["/only", "/route1", "/route2"], "POST"
 
   def call(env)
-    super && return(call_next(env))
+    return unless only_match?(env)
     env.response.print "Only"
     call_next env
   end
@@ -41,7 +41,7 @@ class PostExcludeHandler < Kemal::Handler
   exclude ["/exclude"], "POST"
 
   def call(env)
-    super && return(call_next(env))
+    return unless exclude_match?(env)
     env.response.print "Exclude"
     call_next env
   end

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -11,7 +11,7 @@ class OnlyHandler < Kemal::Handler
   only ["/only"]
 
   def call(env)
-    return unless only_match?(env)
+    return call_next(env) unless only_match?(env)
     env.response.print "Only"
     call_next env
   end
@@ -21,7 +21,7 @@ class ExcludeHandler < Kemal::Handler
   exclude ["/exclude"]
 
   def call(env)
-    return unless exclude_match?(env)
+    return call_next(env) if exclude_match?(env)
     env.response.print "Exclude"
     call_next env
   end
@@ -31,7 +31,7 @@ class PostOnlyHandler < Kemal::Handler
   only ["/only", "/route1", "/route2"], "POST"
 
   def call(env)
-    return unless only_match?(env)
+    return call_next(env) unless only_match?(env)
     env.response.print "Only"
     call_next env
   end
@@ -41,7 +41,7 @@ class PostExcludeHandler < Kemal::Handler
   exclude ["/exclude"], "POST"
 
   def call(env)
-    return unless exclude_match?(env)
+    return call_next(env) if exclude_match?(env)
     env.response.print "Exclude"
     call_next env
   end

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -104,7 +104,7 @@ describe "Handler" do
     client_response.body.should eq "OnlyPost"
   end
 
-  it "runs specified exclude_routes with method in middleware" do
+  it "doesn't run specified exclude_routes with method in middleware" do
     post "/exclude" do
       "Post"
     end

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -1,6 +1,7 @@
 require "http"
 require "multipart"
 require "./kemal/*"
+require "./kemal/ext/*"
 require "./kemal/helpers/*"
 require "./kemal/middleware/*"
 

--- a/src/kemal/ext/handler.cr
+++ b/src/kemal/ext/handler.cr
@@ -1,0 +1,49 @@
+# Extend HTTP::Handler so that certain macros are scoped to HTTP::Handler or
+# inheriting classes, and not part of the global scope
+class HTTP::Handler
+  @@only_routes_tree = Radix::Tree(String).new
+  @@exclude_routes_tree = Radix::Tree(String).new
+
+  private def radix_path(method : String, path)
+    "/#{method.downcase}#{path}"
+  end
+end
+
+class Kemal::Handler < HTTP::Handler
+  macro only(paths, method = "GET")
+    class_name = {{@type.name}}
+    {{paths}}.each do |path|
+      @@only_routes_tree.add "#{class_name}/#{{{method}}.downcase}#{path}", "/#{{{method}}.downcase}#{path}"
+    end
+  end
+
+  macro exclude(paths, method = "GET")
+    class_name = {{@type.name}}
+    {{paths}}.each do |path|
+      @@exclude_routes_tree.add "#{class_name}/#{{{method}}.downcase}#{path}", "/#{{{method}}.downcase}#{path}"
+    end
+  end
+
+  def call(env)
+    if @@only_routes_tree || @@exclude_routes_tree
+      only_found = false
+      exclude_found = false
+      if @@only_routes_tree
+        only_found = @@only_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
+      end
+      if @@exclude_routes_tree
+        exclude_found = @@exclude_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
+      end
+      if only_found && !exclude_found
+        return false
+      else
+        return true
+      end
+    end
+    return false
+  end
+
+  private def radix_path(method : String, path)
+    "#{self.class}/#{method.downcase}#{path}"
+  end
+end

--- a/src/kemal/ext/handler.cr
+++ b/src/kemal/ext/handler.cr
@@ -16,6 +16,22 @@ class Kemal::Handler < HTTP::Handler
     end
   end
 
+  # Processes the path based on `only/exclude` paths which is a `Array(String)`.
+  # If the path is not found on `only` and `exclude` conditions the handler will continue processing.
+  # If the path is found in `only` or `exclude` conditions it'll stop processing and will pass the request
+  # to next handler.
+  #
+  # However this is not done automatically. All handlers must inherit from `Kemal::Handler` and need to explicitly
+  # call `super && return(call_next(env))`.
+  #
+  #     OnlyHandler < Kemal::Handler
+  #       only ["/"]
+  #
+  #       def call(env)
+  #         super && return(call_next(env))
+  #         puts "If the path is / i will be doing some processing here."
+  #       end
+  #     end
   def call(env)
     if @@only_routes_tree || @@exclude_routes_tree
       only_found = false

--- a/src/kemal/ext/handler.cr
+++ b/src/kemal/ext/handler.cr
@@ -1,15 +1,7 @@
-# Extend HTTP::Handler so that certain macros are scoped to HTTP::Handler or
-# inheriting classes, and not part of the global scope
-class HTTP::Handler
+class Kemal::Handler < HTTP::Handler
   @@only_routes_tree = Radix::Tree(String).new
   @@exclude_routes_tree = Radix::Tree(String).new
 
-  private def radix_path(method : String, path)
-    "/#{method.downcase}#{path}"
-  end
-end
-
-class Kemal::Handler < HTTP::Handler
   macro only(paths, method = "GET")
     class_name = {{@type.name}}
     {{paths}}.each do |path|

--- a/src/kemal/ext/handler.cr
+++ b/src/kemal/ext/handler.cr
@@ -31,10 +31,12 @@ class Kemal::Handler < HTTP::Handler
       if @@only_routes_tree
         only_found = @@only_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
       end
+
       if @@exclude_routes_tree
         exclude_found = @@exclude_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
       end
-      if only_found && !exclude_found
+
+      if !exclude_found || only_found
         return false
       else
         return true

--- a/src/kemal/ext/handler.cr
+++ b/src/kemal/ext/handler.cr
@@ -31,17 +31,12 @@ class Kemal::Handler < HTTP::Handler
   #       only ["/"]
   #
   #       def call(env)
-  #         return unless only_match?(env)
+  #         return call_next(env) unless only_match?(env)
   #         puts "If the path is / i will be doing some processing here."
   #       end
   #     end
   def only_match?(env)
-    if @@only_routes_tree
-      only_found = false
-      only_found? = @@only_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
-      return only_found?
-    end
-    false
+    @@only_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
   end
 
   # Processes the path based on `exclude` paths which is a `Array(String)`.
@@ -55,17 +50,12 @@ class Kemal::Handler < HTTP::Handler
   #       exclude ["/"]
   #
   #       def call(env)
-  #         return unless exclude_match?(env)
-  #         puts "If the path is / i will be doing some processing here."
+  #         return call_next(env) if exclude_match?(env)
+  #         puts "If the path is not / i will be doing some processing here."
   #       end
   #     end
   def exclude_match?(env)
-    if @@exclude_routes_tree
-      exclude_found = false
-      exclude_found? = @@exclude_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
-      return !exclude_found?
-    end
-    false
+    @@exclude_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
   end
 
   private def radix_path(method : String, path)

--- a/src/kemal/ext/handler.cr
+++ b/src/kemal/ext/handler.cr
@@ -16,41 +16,56 @@ class Kemal::Handler < HTTP::Handler
     end
   end
 
-  # Processes the path based on `only/exclude` paths which is a `Array(String)`.
-  # If the path is not found on `only` and `exclude` conditions the handler will continue processing.
-  # If the path is found in `only` or `exclude` conditions it'll stop processing and will pass the request
+  def call(env)
+    call_next(env)
+  end
+
+  # Processes the path based on `only` paths which is a `Array(String)`.
+  # If the path is not found on `only` conditions the handler will continue processing.
+  # If the path is found in `only` conditions it'll stop processing and will pass the request
   # to next handler.
   #
-  # However this is not done automatically. All handlers must inherit from `Kemal::Handler` and need to explicitly
-  # call `super && return(call_next(env))`.
+  # However this is not done automatically. All handlers must inherit from `Kemal::Handler`.
   #
   #     OnlyHandler < Kemal::Handler
   #       only ["/"]
   #
   #       def call(env)
-  #         super && return(call_next(env))
+  #         return unless only_match?(env)
   #         puts "If the path is / i will be doing some processing here."
   #       end
   #     end
-  def call(env)
-    if @@only_routes_tree || @@exclude_routes_tree
+  def only_match?(env)
+    if @@only_routes_tree
       only_found = false
-      exclude_found = false
-      if @@only_routes_tree
-        only_found = @@only_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
-      end
-
-      if @@exclude_routes_tree
-        exclude_found = @@exclude_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
-      end
-
-      if !exclude_found || only_found
-        return false
-      else
-        return true
-      end
+      only_found? = @@only_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
+      return only_found?
     end
-    return false
+    false
+  end
+
+  # Processes the path based on `exclude` paths which is a `Array(String)`.
+  # If the path is not found on `exclude` conditions the handler will continue processing.
+  # If the path is found in `exclude` conditions it'll stop processing and will pass the request
+  # to next handler.
+  #
+  # However this is not done automatically. All handlers must inherit from `Kemal::Handler`.
+  #
+  #     ExcludeHandler < Kemal::Handler
+  #       exclude ["/"]
+  #
+  #       def call(env)
+  #         return unless exclude_match?(env)
+  #         puts "If the path is / i will be doing some processing here."
+  #       end
+  #     end
+  def exclude_match?(env)
+    if @@exclude_routes_tree
+      exclude_found = false
+      exclude_found? = @@exclude_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
+      return !exclude_found?
+    end
+    false
   end
 
   private def radix_path(method : String, path)


### PR DESCRIPTION
This is alternative implementation for `only` and `exclude` paths for a middleware.

This PR requires that from now on all middlewares must inherit from `Kemal::Handler`.

We use the `only/exclude`  macro to define which routes to take action. 

```crystal
class OnlyHandler < Kemal::Handler
  only ["/only"]

  def call(env)
    super && return(call_next(env))
    env.response.print "Only"
    call_next env
  end
end
```

And to explicitly check & return the matching paths `super && return(call_next(env))` must be implemented.

This has really low performance penalty compared to https://github.com/sdogruyol/kemal/pull/244. This approach is more than %50 faster.

//cc @samueleaton @askn @f 
