### PR TITLE
Close repsonse on halt

### DIFF
--- a/src/kemal/helpers/macros.cr
+++ b/src/kemal/helpers/macros.cr
@@ -73,5 +73,6 @@ end
 macro halt(env, status_code = 200, response = "")
   {{env}}.response.status_code = {{status_code}}
   {{env}}.response.print {{response}}
+  {{env}}.response.close
   next
 end


### PR DESCRIPTION
When using `halt` (`return_with`), the response body is not closed and can still be written to.

Example
```ruby
error 403 do
  "Access Forbidden!"
end

get "/" do |env|
  halt env, 403, "Access Denied"
end
```

Hitting the base `/` path would return `"Access DeniedAccess Forbidden!"`. By closing the response, the response body and status code cannot be changed. I am assuming that this is expected behavior when using `halt`.

When doing `env.response.close` the response IO would be closed and the body would be `"Access Denied"`, as expected.

The 403 error block will still run, but any new information attempting to append to the response will be ignored.