### PR TITLE
500 errors log a 200 status

### DIFF
--- a/spec/common_log_handler_spec.cr
+++ b/spec/common_log_handler_spec.cr
@@ -1,5 +1,8 @@
 require "./spec_helper"
 
+class ErrHandler < Kemal::Handler
+  def call(env); env.response.status_code = 418; call_next(env); end
+end
 describe "Kemal::CommonLogHandler" do
   it "logs to the given IO" do
     config = Kemal.config
@@ -18,5 +21,43 @@ describe "Kemal::CommonLogHandler" do
     logger = Kemal::CommonLogHandler.new io
     logger.call(context)
     io.to_s.should_not be nil
+  end
+
+  context "with status code changes" do
+
+    it "logs a 200 status" do
+      get "/" { |env| "Hello" }
+      request = HTTP::Request.new("GET", "/")
+      io = IO::Memory.new
+      logger = Kemal::CommonLogHandler.new io
+      Kemal.config.add_handler(logger)
+      call_request_on_app(request)
+      io.to_s.should match(/200\sGET/)
+    end
+
+    it "logs a 418 status" do
+      error 418 { |env, err| "I'm a teapot" }
+      get "/" { |env| "Hello" }
+      request = HTTP::Request.new("GET", "/")
+      io = IO::Memory.new
+      logger = Kemal::CommonLogHandler.new(io)
+      Kemal.config.add_handler(logger)
+      Kemal.config.add_handler(Kemal::CommonExceptionHandler.new)
+      Kemal.config.add_handler(ErrHandler.new)
+      response = call_request_on_app(request)
+      io.to_s.should match(/418\sGET/)
+    end
+
+    it "logs a 500 status" do
+      error 500 { |env, err| "Oops!" }
+      get "/" { |env| raise "I did it again" }
+      request = HTTP::Request.new("GET", "/")
+      io = IO::Memory.new
+      logger = Kemal::CommonLogHandler.new(io)
+      Kemal.config.add_handler(logger)
+      Kemal.config.add_handler(Kemal::CommonExceptionHandler.new)
+      response = call_request_on_app(request)
+      io.to_s.should match(/500\sGET/)
+    end
   end
 end

--- a/spec/common_log_handler_spec.cr
+++ b/spec/common_log_handler_spec.cr
@@ -54,6 +54,7 @@ describe "Kemal::CommonLogHandler" do
       request = HTTP::Request.new("GET", "/")
       io = IO::Memory.new
       logger = Kemal::CommonLogHandler.new(io)
+      logger logger
       Kemal.config.add_handler(logger)
       Kemal.config.add_handler(Kemal::CommonExceptionHandler.new)
       response = call_request_on_app(request)

--- a/src/kemal/common_exception_handler.cr
+++ b/src/kemal/common_exception_handler.cr
@@ -21,6 +21,7 @@ module Kemal
     def call_exception_with_status_code(context, exception, status_code)
       if Kemal.config.error_handlers.has_key?(status_code)
         context.response.content_type = "text/html" unless context.response.headers.has_key?("Content-Type")
+        context.response.status_code = status_code
         context.response.print Kemal.config.error_handlers[status_code].call(context, exception)
         context
       end


### PR DESCRIPTION
Currently when a 500 error is thrown, kemal will log a 200 status like this:

```text
Exception: Some exception message here
0x10ee6b965: *CallStack::new:CallStack at ??
...more output...

2016-11-22 21:37:26 -0800 200 GET /v1/reports/sales.json 5.34ms
```

This PR fixes the log so it returns the proper status