### PR TITLE
Fix chunked multipart body limits and 413 handling

### DIFF
--- a/spec/exception_handler_spec.cr
+++ b/spec/exception_handler_spec.cr
@@ -229,4 +229,46 @@ describe "Kemal::ExceptionHandler" do
     client_response = call_request_on_app(request)
     client_response.status_code.should eq 404
   end
+
+  it "renders payload too large with 413 from the exception" do
+    error 413 do
+      "payload too large"
+    end
+
+    get "/" do
+      raise Kemal::Exceptions::PayloadTooLarge.new
+    end
+
+    request = HTTP::Request.new("GET", "/")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    Kemal::ExceptionHandler::INSTANCE.next = Kemal::RouteHandler::INSTANCE
+    Kemal::ExceptionHandler::INSTANCE.call(context)
+    response.close
+    io.rewind
+    response = HTTP::Client::Response.from_io(io, decompress: false)
+    response.status_code.should eq 413
+    response.headers["Content-Type"].should eq "text/html"
+    response.body.should eq "payload too large"
+  end
+
+  it "renders payload too large with 413 without a custom handler" do
+    get "/" do
+      raise Kemal::Exceptions::PayloadTooLarge.new
+    end
+
+    request = HTTP::Request.new("GET", "/")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    Kemal::ExceptionHandler::INSTANCE.next = Kemal::RouteHandler::INSTANCE
+    Kemal::ExceptionHandler::INSTANCE.call(context)
+    response.close
+    io.rewind
+    response = HTTP::Client::Response.from_io(io, decompress: false)
+    response.status_code.should eq 413
+    response.headers["Content-Type"].should eq "text/plain"
+    response.body.should eq "Payload Too Large"
+  end
 end

--- a/spec/param_parser_spec.cr
+++ b/spec/param_parser_spec.cr
@@ -1,5 +1,14 @@
 require "./spec_helper"
 
+def multipart_request(body : String, boundary = "AaB03x")
+  headers = HTTP::Headers{
+    "Content-Type"      => "multipart/form-data; boundary=#{boundary}",
+    "Transfer-Encoding" => "chunked",
+  }
+
+  HTTP::Request.new("POST", "/", headers, IO::Memory.new(body))
+end
+
 describe "ParamParser" do
   it "parses query params" do
     Route.new "POST", "/" do |env|
@@ -322,6 +331,79 @@ describe "ParamParser" do
       expect_raises(Kemal::Exceptions::PayloadTooLarge) do
         Kemal::ParamParser.new(request).json
       end
+    end
+
+    it "raises PayloadTooLarge for chunked multipart form fields" do
+      boundary = "AaB03x"
+      body = <<-MULTIPART
+        --#{boundary}\r
+        Content-Disposition: form-data; name="field"\r
+        \r
+        abcdefghijk\r
+        --#{boundary}--\r
+        MULTIPART
+
+      Kemal.config.max_request_body_size = body.bytesize - 1
+      request = multipart_request(body, boundary)
+
+      expect_raises(Kemal::Exceptions::PayloadTooLarge) do
+        Kemal::ParamParser.new(request).body
+      end
+    end
+
+    it "raises PayloadTooLarge for chunked multipart file uploads" do
+      boundary = "AaB03x"
+      body = <<-MULTIPART
+        --#{boundary}\r
+        Content-Disposition: form-data; name="file"; filename="huge.txt"\r
+        Content-Type: text/plain\r
+        \r
+        abcdefghijk\r
+        --#{boundary}--\r
+        MULTIPART
+
+      Kemal.config.max_request_body_size = body.bytesize - 1
+      request = multipart_request(body, boundary)
+
+      expect_raises(Kemal::Exceptions::PayloadTooLarge) do
+        Kemal::ParamParser.new(request).files
+      end
+    end
+
+    it "raises PayloadTooLarge when multipart form field exceeds its own limit" do
+      boundary = "AaB03x"
+      body = <<-MULTIPART
+        --#{boundary}\r
+        Content-Disposition: form-data; name="field"\r
+        \r
+        abcdefghijk\r
+        --#{boundary}--\r
+        MULTIPART
+
+      Kemal.config.max_request_body_size = body.bytesize + 100
+      Kemal.config.max_multipart_form_field_size = 5
+      request = multipart_request(body, boundary)
+
+      expect_raises(Kemal::Exceptions::PayloadTooLarge) do
+        Kemal::ParamParser.new(request).body
+      end
+    end
+
+    it "parses multipart form field within its own limit" do
+      boundary = "AaB03x"
+      body = <<-MULTIPART
+        --#{boundary}\r
+        Content-Disposition: form-data; name="field"\r
+        \r
+        hello\r
+        --#{boundary}--\r
+        MULTIPART
+
+      Kemal.config.max_request_body_size = body.bytesize + 100
+      Kemal.config.max_multipart_form_field_size = 10
+      request = multipart_request(body, boundary)
+
+      Kemal::ParamParser.new(request).body["field"].should eq("hello")
     end
   end
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -28,6 +28,7 @@ module Kemal
     property? powered_by_header : Bool = true
     property max_route_cache_size : Int32
     property max_request_body_size : Int32
+    property max_multipart_form_field_size : Int32
 
     def initialize
       @app_name = "Kemal"
@@ -47,7 +48,8 @@ module Kemal
       @shutdown_timeout = 0.seconds
       @handler_position = 0
       @max_route_cache_size = 1024
-      @max_request_body_size = 8 * 1024 * 1024 # 8MB
+      @max_request_body_size = 8 * 1024 * 1024         # 8MB
+      @max_multipart_form_field_size = 8 * 1024 * 1024 # 8MB
     end
 
     @[Deprecated("Use standard library Log")]
@@ -76,6 +78,7 @@ module Kemal
       @default_handlers_setup = false
       @max_route_cache_size = 1024
       @max_request_body_size = 8 * 1024 * 1024
+      @max_multipart_form_field_size = 8 * 1024 * 1024
       HANDLERS.clear
       CUSTOM_HANDLERS.clear
       FILTER_HANDLERS.clear

--- a/src/kemal/exception_handler.cr
+++ b/src/kemal/exception_handler.cr
@@ -11,7 +11,11 @@ module Kemal
     rescue ex : Kemal::Exceptions::CustomException
       call_exception_with_status_code(context, ex, context.response.status_code)
     rescue ex : Kemal::Exceptions::PayloadTooLarge
-      call_exception_with_status_code(context, ex, 413)
+      if Kemal.config.error_handlers.has_key?(413)
+        call_exception_with_status_code(context, ex, 413)
+      else
+        call_payload_too_large(context, ex)
+      end
     rescue ex : Exception
       # Matches an error handler for the given exception
       #
@@ -56,6 +60,15 @@ module Kemal
         context.response.print Kemal.config.error_handlers[status_code].call(context, exception)
         context
       end
+    end
+
+    private def call_payload_too_large(context : HTTP::Server::Context, exception : Kemal::Exceptions::PayloadTooLarge)
+      return if context.response.closed?
+
+      context.response.content_type = "text/plain" unless context.response.headers.has_key?("Content-Type")
+      context.response.status_code = 413
+      context.response.print exception.message if exception.message
+      context
     end
   end
 end

--- a/src/kemal/file_upload.cr
+++ b/src/kemal/file_upload.cr
@@ -10,8 +10,13 @@ module Kemal
 
     def initialize(upload)
       @tempfile = File.tempfile
-      ::File.open(@tempfile.path, "w") do |file|
-        IO.copy(upload.body, file)
+      begin
+        ::File.open(@tempfile.path, "w") do |file|
+          IO.copy(upload.body, file)
+        end
+      rescue ex
+        cleanup
+        raise ex
       end
       @filename = upload.filename
       @headers = upload.headers

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -3,6 +3,58 @@ module Kemal
   # and converts them into a params hash which you can use within
   # the environment context.
   class ParamParser
+    private class LimitedBodyIO < IO
+      @closed = false
+      @bytes_read = 0_i64
+
+      def initialize(@io : IO, limit : Int32)
+        @limit = limit.to_i64
+      end
+
+      def read(slice : Bytes) : Int32
+        check_open
+
+        bytes_read = @io.read(slice)
+        increment_bytes_read(bytes_read.to_i64)
+        bytes_read
+      end
+
+      def read_byte : UInt8?
+        check_open
+
+        byte = @io.read_byte
+        increment_bytes_read(1_i64) if byte
+        byte
+      end
+
+      def peek : Bytes?
+        check_open
+        @io.peek
+      end
+
+      def skip(bytes_count) : Nil
+        check_open
+
+        @io.skip(bytes_count)
+        increment_bytes_read(bytes_count.to_i64)
+      end
+
+      def write(slice : Bytes) : NoReturn
+        raise IO::Error.new "Can't write to LimitedBodyIO"
+      end
+
+      def close : Nil
+        @closed = true
+      end
+
+      private def increment_bytes_read(bytes_count : Int64)
+        return if bytes_count <= 0
+
+        @bytes_read += bytes_count
+        raise Exceptions::PayloadTooLarge.new if @bytes_read > @limit
+      end
+    end
+
     URL_ENCODED_FORM = "application/x-www-form-urlencoded"
     APPLICATION_JSON = "application/json"
     MULTIPART_FORM   = "multipart/form-data"
@@ -111,7 +163,7 @@ module Kemal
 
       validate_content_length!
 
-      HTTP::FormData.parse(@request) do |upload|
+      HTTP::FormData.parse(multipart_body_with_limit, multipart_boundary) do |upload|
         next unless upload
 
         filename = upload.filename
@@ -125,7 +177,7 @@ module Kemal
             @files[name] = FileUpload.new(upload)
           end
         else
-          @body.add(name, upload.body.gets_to_end)
+          @body.add(name, read_body_with_limit(upload.body, multipart_form_field_limit))
         end
       end
 
@@ -172,14 +224,32 @@ module Kemal
       raise Exceptions::PayloadTooLarge.new
     end
 
-    private def read_body_with_limit(io : IO) : String
-      limit = Kemal.config.max_request_body_size
+    private def read_body_with_limit(io : IO, limit : Int32 = Kemal.config.max_request_body_size) : String
       String.build do |str|
         bytes_read = IO.copy(io, str, limit + 1)
         if bytes_read > limit
           raise Exceptions::PayloadTooLarge.new
         end
       end
+    end
+
+    private def multipart_form_field_limit : Int32
+      Kemal.config.max_multipart_form_field_size
+    end
+
+    private def multipart_body_with_limit : IO
+      body = @request.body
+      raise HTTP::FormData::Error.new("Cannot extract form-data from HTTP request: body is empty") unless body
+
+      LimitedBodyIO.new(body, Kemal.config.max_request_body_size)
+    end
+
+    private def multipart_boundary : String
+      content_type = @request.headers["Content-Type"]?
+      boundary = content_type.try { |header| MIME::Multipart.parse_boundary(header) }
+      raise HTTP::FormData::Error.new("Cannot extract form-data from HTTP request: could not find boundary in Content-Type") unless boundary
+
+      boundary
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes the multipart request size handling reported in #747.

Kemal previously did not reliably enforce `Kemal.config.max_request_body_size` for `multipart/form-data` requests sent with `Transfer-Encoding: chunked`. This allowed oversized multipart payloads to bypass the intended limit and consume excessive server resources.

This PR closes that gap by enforcing limits during multipart streaming, ensuring `PayloadTooLarge` consistently returns `413`, and tightening the handling of multipart text fields that are materialized in memory.

## What Changed

- Enforced request body size limits while parsing chunked multipart requests instead of relying only on `Content-Length`
- Applied the limit to both multipart file uploads and multipart non-file form fields
- Ensured `Kemal::Exceptions::PayloadTooLarge` carries a `413` status code
- Updated exception handling so `PayloadTooLarge` returns `413` even when no custom `413` error handler is defined
- Added cleanup for partially written temp files when multipart file uploads are interrupted by `PayloadTooLarge`
- Introduced `Kemal.config.max_multipart_form_field_size` to separately limit multipart text fields that are stored in memory
- Set the default `max_multipart_form_field_size` to `8MB`

## Why This Matters

There were two related issues behind #747:

1. `chunked multipart/form-data` requests could bypass the configured request body limit because there was no `Content-Length` header to reject up front.
2. Multipart fields without a filename, such as requests created with `curl -F "file=<large_file.txt"`, were treated as regular form fields and materialized into memory as a `String`.

With this change:
- oversized chunked multipart file uploads now fail with `413 Payload Too Large`
- oversized chunked multipart text fields now fail with `413 Payload Too Large`
- multipart file uploads interrupted by size enforcement no longer leave partial temp files behind

## Configuration

This PR adds a new config option:

```crystal
Kemal.config.max_multipart_form_field_size = 8 * 1024 * 1024