### PR TITLE
Add Websocket origin validation and configuration support

### DIFF
--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -1,5 +1,16 @@
 require "./spec_helper"
 
+def ws_upgrade_headers_for_origin(origin : String? = nil)
+  h = HTTP::Headers{
+    "Upgrade"               => "websocket",
+    "Connection"            => "Upgrade",
+    "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
+    "Sec-WebSocket-Version" => "13",
+  }
+  h["Origin"] = origin if origin
+  h
+end
+
 describe "Kemal::WebSocketHandler" do
   it "doesn't match on wrong route" do
     handler = Kemal::WebSocketHandler::INSTANCE
@@ -64,5 +75,57 @@ describe "Kemal::WebSocketHandler" do
     io.rewind
     client_response = HTTP::Client::Response.from_io(io, decompress: false)
     client_response.body.should eq("get")
+  end
+
+  describe "websocket_allowed_origins" do
+    it "rejects 403 when allowlist is set and Origin is missing" do
+      Kemal.config.websocket_allowed_origins = ["https://app.example.com"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin)
+      io = IO::Memory.new
+      response = HTTP::Server::Response.new(io)
+      context = HTTP::Server::Context.new(request, response)
+      handler.call(context)
+      response.close
+      io.rewind
+      client_response = HTTP::Client::Response.from_io(io, decompress: false)
+      client_response.status_code.should eq(403)
+      client_response.body.should eq("Forbidden")
+    end
+
+    it "rejects 403 when Origin is not in allowlist" do
+      Kemal.config.websocket_allowed_origins = ["https://app.example.com"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("https://evil.example"))
+      io = IO::Memory.new
+      response = HTTP::Server::Response.new(io)
+      context = HTTP::Server::Context.new(request, response)
+      handler.call(context)
+      response.close
+      io.rewind
+      client_response = HTTP::Client::Response.from_io(io, decompress: false)
+      client_response.status_code.should eq(403)
+    end
+
+    it "allows upgrade when Origin matches allowlist" do
+      Kemal.config.websocket_allowed_origins = ["https://App.EXAMPLE.com"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws("/", &.send("ok"))
+      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("https://app.example.com"))
+      io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
+      io_with_context.to_s.should contain("101 Switching Protocols")
+      io_with_context.to_s.should contain("\x81\u0002ok")
+    end
+
+    it "normalizes default https port against allowlist" do
+      Kemal.config.websocket_allowed_origins = ["https://example.com"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws("/", &.send("x"))
+      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("https://example.com:443"))
+      io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
+      io_with_context.to_s.should contain("101 Switching Protocols")
+    end
   end
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -28,6 +28,11 @@ module Kemal
     property? powered_by_header : Bool = true
     property max_route_cache_size : Int32
     property max_request_body_size : Int32
+    # When non-empty, WebSocket upgrade requests must send an `Origin` header that matches
+    # one of these values (after normalization: scheme/host/port only). Entries use the
+    # serialized origin form, e.g. `"https://example.com"` or `"http://localhost:3000"`.
+    # Use `"null"` to allow the browser's opaque `"null"` origin.
+    property websocket_allowed_origins : Array(String)
 
     def initialize
       @app_name = "Kemal"
@@ -48,6 +53,7 @@ module Kemal
       @handler_position = 0
       @max_route_cache_size = 1024
       @max_request_body_size = 8 * 1024 * 1024 # 8MB
+      @websocket_allowed_origins = [] of String
     end
 
     @[Deprecated("Use standard library Log")]
@@ -76,6 +82,7 @@ module Kemal
       @default_handlers_setup = false
       @max_route_cache_size = 1024
       @max_request_body_size = 8 * 1024 * 1024
+      @websocket_allowed_origins = [] of String
       HANDLERS.clear
       CUSTOM_HANDLERS.clear
       FILTER_HANDLERS.clear

--- a/src/kemal/websocket_handler.cr
+++ b/src/kemal/websocket_handler.cr
@@ -11,6 +11,10 @@ module Kemal
 
     def call(context : HTTP::Server::Context)
       return call_next(context) unless context.ws_route_found? && websocket_upgrade_request?(context)
+      unless websocket_origin_allowed?(context.request)
+        reject_websocket_forbidden!(context)
+        return
+      end
       context.websocket.call(context)
     end
 
@@ -36,6 +40,48 @@ module Kemal
       return unless upgrade.compare("websocket", case_insensitive: true) == 0
 
       context.request.headers.includes_word?("Connection", "Upgrade")
+    end
+
+    private def websocket_origin_allowed?(request : HTTP::Request) : Bool
+      allowed = Kemal.config.websocket_allowed_origins
+      return true if allowed.empty?
+
+      origin_header = request.headers["Origin"]?
+      return false if !origin_header || origin_header.empty?
+
+      actual = normalize_websocket_origin(origin_header)
+      return false unless actual
+
+      allowed.any? { |entry| normalize_websocket_origin(entry) == actual }
+    end
+
+    private def normalize_websocket_origin(origin : String) : String?
+      o = origin.strip
+      return if o.empty?
+      return "null" if o == "null"
+
+      uri = URI.parse(o)
+      scheme_raw = uri.scheme
+      host_raw = uri.host
+      return unless scheme_raw && host_raw
+
+      scheme = scheme_raw.downcase
+      host = host_raw.downcase
+      port = uri.port
+      default = URI.default_port(scheme)
+      if port && default && port == default
+        "#{scheme}://#{host}"
+      elsif port
+        "#{scheme}://#{host}:#{port}"
+      else
+        "#{scheme}://#{host}"
+      end
+    end
+
+    private def reject_websocket_forbidden!(context : HTTP::Server::Context)
+      context.response.status_code = 403
+      context.response.headers["Content-Type"] = "text/plain; charset=UTF-8"
+      context.response.print "Forbidden"
     end
   end
 end


### PR DESCRIPTION
## Summary

Security reviews often require validating the `Origin` header on **WebSocket** upgrade requests against an explicit allowlist and rejecting mismatches with **403 Forbidden** before the protocol switch. This adds optional, configuration-driven Origin checks to Kemal while keeping backward-compatible defaults.

## Problem

- Browsers send an `Origin` header on WebSocket handshakes (similar in spirit to CORS for fetches).
- Without checking `Origin`, a malicious page can try to open a WebSocket to your app from a victim’s browser. That matters especially when sessions are cookie-based, because the browser may attach cookies to the upgrade request depending on site policy.
- CORS settings do not automatically protect WebSocket upgrades; the WebSocket path needs its own policy.

## Solution

- New config: `Kemal::Config#websocket_allowed_origins : Array(String)` (default: empty).
- **`websocket_allowed_origins` empty:** no Origin validation — existing behavior unchanged (tests, `curl`, non-browser clients).
- **`websocket_allowed_origins` non-empty:** upgrade must include `Origin` that matches one entry after normalization; otherwise **403** and **no** protocol upgrade.

### Matching rules

| Rule | Detail |
|------|--------|
| Scheme / host | Compared case-insensitively |
| Ports | Default ports normalized (e.g. `https://example.com` ↔ `https://example.com:443`) |
| Path | Only scheme/host/port used; extra path in a configured string is not part of the origin tuple |
| Opaque origin | Browser may send `Origin: null`; allow only if `"null"` is explicitly in the list |

## Configuration example

```crystal
Kemal.config do |c|
  c.websocket_allowed_origins = [
    "https://myapp.com",
    "http://localhost:3000",
  ]
end
```
Use the real browser origins (correct scheme and hostname), not only the server bind address.

## Why the default is an empty allowlist
- Public origin often differs from host_binding + port (TLS at reverse proxy, multiple domains, Forwarded / X-Forwarded-*).
- Strict defaults would break tests and clients that omit Origin.
- Teams that need audit compliance opt in by setting the list.