### PR TITLE
Add `sse` helper for Server-Sent Events

### DIFF
--- a/examples/sse/app.cr
+++ b/examples/sse/app.cr
@@ -1,0 +1,32 @@
+require "kemal"
+
+sse "/events" do |stream, _|
+  3.times do |i|
+    stream.send("tick #{i + 1}", event: "tick", id: i + 1)
+    sleep 1
+  end
+end
+
+get "/" do
+  <<-HTML
+    <!DOCTYPE html>
+    <html>
+      <head><title>SSE Example</title></head>
+      <body>
+        <h1>Server-Sent Events</h1>
+        <ul id="events"></ul>
+        <script>
+          const list = document.getElementById("events");
+          const source = new EventSource("/events");
+          source.addEventListener("tick", (event) => {
+            const item = document.createElement("li");
+            item.textContent = event.data;
+            list.appendChild(item);
+          });
+        </script>
+      </body>
+    </html>
+    HTML
+end
+
+Kemal.run

--- a/spec/event_stream_spec.cr
+++ b/spec/event_stream_spec.cr
@@ -1,0 +1,94 @@
+require "./spec_helper"
+
+describe Kemal::EventStream do
+  it "sends events with SSE headers" do
+    sse "/events" do |stream, _|
+      stream.send("hello")
+    end
+
+    request = HTTP::Request.new("GET", "/events")
+    client_response = call_request_on_app(request)
+    client_response.status_code.should eq(200)
+    client_response.headers["Content-Type"].should eq("text/event-stream; charset=utf-8")
+    client_response.headers["Cache-Control"].should eq("no-cache")
+    client_response.body.should eq("data: hello\n\n")
+  end
+
+  it "sends event with name, id, and retry" do
+    sse "/events" do |stream, _|
+      stream.send("update", event: "tick", id: 42, retry: 3000)
+    end
+
+    request = HTTP::Request.new("GET", "/events")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("event: tick\nid: 42\nretry: 3000\ndata: update\n\n")
+  end
+
+  it "splits multi-line data into separate data fields" do
+    sse "/events" do |stream, _|
+      stream.send("line one\nline two")
+    end
+
+    request = HTTP::Request.new("GET", "/events")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("data: line one\ndata: line two\n\n")
+  end
+
+  it "sends keep-alive comments" do
+    sse "/events" do |stream, _|
+      stream.comment("ping")
+    end
+
+    request = HTTP::Request.new("GET", "/events")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq(": ping\n\n")
+  end
+
+  it "supports url parameters" do
+    sse "/events/:channel" do |stream, env|
+      stream.send(env.params.url["channel"])
+    end
+
+    request = HTTP::Request.new("GET", "/events/news")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("data: news\n\n")
+  end
+
+  it "does not append extra body when handler returns EventStream" do
+    sse "/events" do |stream, _|
+      stream.send("only this")
+    end
+
+    request = HTTP::Request.new("GET", "/events")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("data: only this\n\n")
+  end
+
+  it "requires path to start with /" do
+    expect_raises Kemal::Exceptions::InvalidPathStartException do
+      sse "events" { |_, _| }
+    end
+  end
+
+  it "registers as GET route only" do
+    sse "/events" { |_, _| }
+
+    Kemal::RouteHandler::INSTANCE.lookup_route("GET", "/events").found?.should be_true
+    Kemal::RouteHandler::INSTANCE.lookup_route("POST", "/events").found?.should be_false
+  end
+end
+
+describe "Kemal::Router SSE" do
+  it "registers SSE routes with prefix" do
+    router = Kemal::Router.new
+    router.sse "/events" do |stream, _|
+      stream.send("mounted")
+    end
+
+    mount "/api", router
+
+    request = HTTP::Request.new("GET", "/api/events")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("data: mounted\n\n")
+  end
+end

--- a/spec/event_stream_spec.cr
+++ b/spec/event_stream_spec.cr
@@ -11,12 +11,13 @@ describe Kemal::EventStream do
     client_response.status_code.should eq(200)
     client_response.headers["Content-Type"].should eq("text/event-stream; charset=utf-8")
     client_response.headers["Cache-Control"].should eq("no-cache")
+    client_response.headers["X-Accel-Buffering"].should eq("no")
     client_response.body.should eq("data: hello\n\n")
   end
 
   it "sends event with name, id, and retry" do
     sse "/events" do |stream, _|
-      stream.send("update", event: "tick", id: 42, retry: 3000)
+      stream.send("update", event: "tick", id: 42, retry: 3.seconds)
     end
 
     request = HTTP::Request.new("GET", "/events")

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -5,6 +5,7 @@
 #
 # - **HTTP Routes**: `get`, `post`, `put`, `patch`, `delete`, `options`
 # - **WebSocket**: `ws`
+# - **Server-Sent Events**: `sse`
 # - **Filters**: `before_all`, `before_get`, `after_all`, `after_get`, etc.
 # - **Error Handling**: `error`
 # - **Modular Routing**: `mount`
@@ -45,6 +46,25 @@ FILTER_METHODS = %w[get post put patch delete options all]
 def ws(path : String, &block : HTTP::WebSocket, HTTP::Server::Context ->)
   raise Kemal::Exceptions::InvalidPathStartException.new("ws", path) unless Kemal::Utils.path_starts_with_slash?(path)
   Kemal::WebSocketHandler::INSTANCE.add_route path, &block
+end
+
+# Defines a Server-Sent Events (SSE) route.
+#
+# NOTE: The path must start with a `/`.
+#
+# ```
+# sse "/events" do |stream, env|
+#   loop do
+#     stream.send("tick #{Time.utc}")
+#     sleep 1
+#   end
+# end
+# ```
+def sse(path : String, &block : Kemal::EventStream, HTTP::Server::Context ->)
+  raise Kemal::Exceptions::InvalidPathStartException.new("sse", path) unless Kemal::Utils.path_starts_with_slash?(path)
+  Kemal::RouteHandler::INSTANCE.add_route("GET", path) do |env|
+    Kemal::EventStream.serve(env, &block)
+  end
 end
 
 # Defines an error handler for the given HTTP status code.

--- a/src/kemal/event_stream.cr
+++ b/src/kemal/event_stream.cr
@@ -1,0 +1,53 @@
+module Kemal
+  # Helper for Server-Sent Events (SSE) responses.
+  #
+  # Sets the required headers and formats events according to the SSE spec.
+  class EventStream
+    def initialize(@response : HTTP::Server::Response)
+      setup_headers
+    end
+
+    # Runs an SSE handler with headers configured and yields an `EventStream`.
+    def self.serve(context : HTTP::Server::Context, &block : EventStream, HTTP::Server::Context ->)
+      stream = new(context.response)
+      yield stream, context
+      stream
+    end
+
+    # Sends an SSE event. Multi-line *data* is split into separate `data:` fields.
+    def send(data : String, *, event : String? = nil, id : String | Int? = nil, retry : Int32? = nil) : self
+      @response.print "event: #{event}\n" if event
+      @response.print "id: #{id}\n" if id
+      @response.print "retry: #{retry}\n" if retry
+      data.each_line(chomp: true) do |line|
+        @response.print "data: #{line}\n"
+      end
+      @response.print "\n"
+      flush
+      self
+    end
+
+    # Sends a keep-alive comment (ignored by clients, useful during idle periods).
+    def comment(text : String) : self
+      @response.print ": #{text}\n\n"
+      flush
+      self
+    end
+
+    def flush : Nil
+      @response.flush
+    end
+
+    def close : Nil
+      @response.close
+    end
+
+    private def setup_headers
+      @response.content_type = "text/event-stream; charset=utf-8"
+      @response.headers["Cache-Control"] = "no-cache"
+      unless @response.headers.has_key?("Connection")
+        @response.headers["Connection"] = "keep-alive"
+      end
+    end
+  end
+end

--- a/src/kemal/event_stream.cr
+++ b/src/kemal/event_stream.cr
@@ -8,21 +8,21 @@ module Kemal
     end
 
     # Runs an SSE handler with headers configured and yields an `EventStream`.
-    def self.serve(context : HTTP::Server::Context, &block : EventStream, HTTP::Server::Context ->)
+    def self.serve(context : HTTP::Server::Context, & : EventStream, HTTP::Server::Context ->)
       stream = new(context.response)
       yield stream, context
       stream
     end
 
     # Sends an SSE event. Multi-line *data* is split into separate `data:` fields.
-    def send(data : String, *, event : String? = nil, id : String | Int? = nil, retry : Int32? = nil) : self
-      @response.print "event: #{event}\n" if event
-      @response.print "id: #{id}\n" if id
-      @response.print "retry: #{retry}\n" if retry
+    def send(data : String, *, event : String? = nil, id : String | Int? = nil, retry : Time::Span? = nil) : self
+      @response.puts "event: #{event}" if event
+      @response.puts "id: #{id}" if id
+      @response.puts "retry: #{retry.total_milliseconds.to_i}" if retry
       data.each_line(chomp: true) do |line|
-        @response.print "data: #{line}\n"
+        @response.puts "data: #{line}"
       end
-      @response.print "\n"
+      @response.puts
       flush
       self
     end
@@ -45,6 +45,7 @@ module Kemal
     private def setup_headers
       @response.content_type = "text/event-stream; charset=utf-8"
       @response.headers["Cache-Control"] = "no-cache"
+      @response.headers["X-Accel-Buffering"] = "no"
       unless @response.headers.has_key?("Connection")
         @response.headers["Connection"] = "keep-alive"
       end

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -167,6 +167,8 @@ module Kemal
         raise Kemal::Exceptions::CustomException.new(context)
       end
 
+      return if context.response.closed?
+
       context.response.print(content)
 
       context

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -167,8 +167,6 @@ module Kemal
         raise Kemal::Exceptions::CustomException.new(context)
       end
 
-      return if context.response.closed?
-
       context.response.print(content)
 
       context

--- a/src/kemal/router.cr
+++ b/src/kemal/router.cr
@@ -29,6 +29,7 @@ module Kemal
     alias RouteHandler = HTTP::Server::Context -> String
     alias FilterHandler = HTTP::Server::Context -> String
     alias WSHandler = HTTP::WebSocket, HTTP::Server::Context ->
+    alias SSEHandler = EventStream, HTTP::Server::Context ->
 
     # Stored route definition
     private record RouteDefinition,
@@ -48,6 +49,11 @@ module Kemal
       path : String,
       handler : WSHandler
 
+    # Stored SSE definition
+    private record SSEDefinition,
+      path : String,
+      handler : SSEHandler
+
     # Stored sub-router
     private record SubRouter,
       path : String,
@@ -58,12 +64,14 @@ module Kemal
     @routes : Array(RouteDefinition)
     @filters : Array(FilterDefinition)
     @websockets : Array(WSDefinition)
+    @sse_routes : Array(SSEDefinition)
     @sub_routers : Array(SubRouter)
 
     def initialize(@prefix : String = "")
       @routes = [] of RouteDefinition
       @filters = [] of FilterDefinition
       @websockets = [] of WSDefinition
+      @sse_routes = [] of SSEDefinition
       @sub_routers = [] of SubRouter
     end
 
@@ -92,6 +100,17 @@ module Kemal
     # ```
     def ws(path : String, &block : HTTP::WebSocket, HTTP::Server::Context ->)
       @websockets << WSDefinition.new(path: path, handler: block)
+    end
+
+    # Defines a Server-Sent Events (SSE) route.
+    #
+    # ```
+    # router.sse "/events" do |stream, env|
+    #   stream.send("hello")
+    # end
+    # ```
+    def sse(path : String, &block : EventStream, HTTP::Server::Context ->)
+      @sse_routes << SSEDefinition.new(path: path, handler: block)
     end
 
     # Defines a before filter for all HTTP methods.
@@ -204,6 +223,15 @@ module Kemal
         Kemal::WebSocketHandler::INSTANCE.add_route(full_path, &ws_def.handler)
       end
 
+      # Register SSE routes
+      @sse_routes.each do |sse_def|
+        full_path = join_paths(full_prefix, sse_def.path)
+        validate_path!("sse", full_path)
+        Kemal::RouteHandler::INSTANCE.add_route("GET", full_path) do |env|
+          Kemal::EventStream.serve(env, &sse_def.handler)
+        end
+      end
+
       # Register sub-routers recursively
       @sub_routers.each do |sub|
         sub_prefix = join_paths(full_prefix, sub.path)
@@ -219,6 +247,11 @@ module Kemal
       @routes.each do |route|
         full_path = join_paths(full_prefix, route.path)
         paths << {route.method, full_path}
+      end
+
+      @sse_routes.each do |sse_def|
+        full_path = join_paths(full_prefix, sse_def.path)
+        paths << {"GET", full_path}
       end
 
       # Sub-router routes


### PR DESCRIPTION
### Description of the Change
Closes #754
Adds first-class SSE support via a new `sse` DSL keyword and `Kemal::EventStream` helper.

SSE routes are registered as regular `GET` handlers — no separate middleware chain like WebSockets. `EventStream` sets the required headers and formats events (`data`, `event`, `id`, `retry`, comments) with automatic flush.

```crystal
sse "/events" do |stream, env|
  stream.send("tick", event: "tick", id: 1)
end
```
Also adds Router support, an example app, and specs.

### Alternate Designs
Considered a full SSEHandler (mirroring WebSocketHandler), but SSE is plain HTTP streaming, a thin DSL + helper keeps Kemal minimal while improving discoverability.

### Benefits
- Ergonomic, discoverable API alongside ws
- Correct SSE headers and framing out of the box
- Works with HTMX and native EventSource

### Possible Drawbacks
No built-in reconnect/Last-Event-ID state management (can be added later if needed)