### PR TITLE
Update mysql example

### DIFF
--- a/examples/mysql-db/app.cr
+++ b/examples/mysql-db/app.cr
@@ -33,7 +33,7 @@ post "/users" do |env|
   name = env.params.json["name"].as(String)
   email = env.params.json["email"].as(String)
 
-  user = User.from_rs(DBC.query("INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id, name, email", name, email)).first
+  user = User.from_rs(DBC.query("INSERT INTO users (name, email) VALUES (?, ?) RETURNING id, name, email", name, email)).first
 
   {message: "User created with id: #{user.id}"}.to_json
 end


### PR DESCRIPTION
crystal-lang/crystal-mysql placeholders use `?` not `$N`, the example currently uses postgresql syntax which causes an error.

### Description of the Change

Small fix to the mysql example to use the correct crystal-lang/crystal-mysql syntax.

### Benefits

MySQL example runs correctly
