### PR TITLE
Fix before_all filters running twice

### DIFF
--- a/spec/middleware/filters_spec.cr
+++ b/spec/middleware/filters_spec.cr
@@ -208,6 +208,90 @@ describe "Kemal::FilterHandler" do
     client_response.body.should eq("true-true")
   end
 
+  it "executes before_all filter only once per request" do
+    execution_count = 0
+
+    filter_middleware = Kemal::FilterHandler.new
+    filter_middleware._add_route_filter("ALL", "*", :before) { execution_count += 1 }
+
+    kemal = Kemal::RouteHandler::INSTANCE
+    kemal.add_route "GET", "/" { "home" }
+    kemal.add_route "GET", "/about" { "about" }
+
+    request = HTTP::Request.new("GET", "/")
+    create_request_and_return_io_and_context(filter_middleware, request)
+    create_request_and_return_io_and_context(kemal, request)
+    execution_count.should eq(1)
+
+    request = HTTP::Request.new("GET", "/about")
+    create_request_and_return_io_and_context(filter_middleware, request)
+    create_request_and_return_io_and_context(kemal, request)
+    execution_count.should eq(2)
+  end
+
+  it "executes before_all and path-specific filters once each" do
+    global_count = 0
+    path_count = 0
+
+    filter_middleware = Kemal::FilterHandler.new
+    filter_middleware._add_route_filter("ALL", "*", :before) { global_count += 1 }
+    filter_middleware._add_route_filter("ALL", "/about", :before) { path_count += 1 }
+
+    kemal = Kemal::RouteHandler::INSTANCE
+    kemal.add_route "GET", "/about" { "about" }
+
+    request = HTTP::Request.new("GET", "/about")
+    create_request_and_return_io_and_context(filter_middleware, request)
+    create_request_and_return_io_and_context(kemal, request)
+
+    global_count.should eq(1)
+    path_count.should eq(1)
+  end
+
+  it "executes before_all /* and /api/* filters correctly" do
+    global_count = 0
+    api_count = 0
+
+    filter_middleware = Kemal::FilterHandler.new
+    filter_middleware._add_route_filter("ALL", "/*", :before) { global_count += 1 }
+    filter_middleware._add_route_filter("ALL", "/api/*", :before) { api_count += 1 }
+
+    kemal = Kemal::RouteHandler::INSTANCE
+    kemal.add_route "GET", "/" { "home" }
+    kemal.add_route "GET", "/api/users" { "users" }
+
+    request = HTTP::Request.new("GET", "/")
+    create_request_and_return_io_and_context(filter_middleware, request)
+    create_request_and_return_io_and_context(kemal, request)
+    global_count.should eq(1)
+    api_count.should eq(0)
+
+    request = HTTP::Request.new("GET", "/api/users")
+    create_request_and_return_io_and_context(filter_middleware, request)
+    create_request_and_return_io_and_context(kemal, request)
+    global_count.should eq(2)
+    api_count.should eq(1)
+  end
+
+  it "treats * and /* as the same global filter path" do
+    star_count = 0
+    slash_star_count = 0
+
+    filter_middleware = Kemal::FilterHandler.new
+    filter_middleware._add_route_filter("ALL", "*", :before) { star_count += 1 }
+    filter_middleware._add_route_filter("ALL", "/*", :before) { slash_star_count += 1 }
+
+    kemal = Kemal::RouteHandler::INSTANCE
+    kemal.add_route "GET", "/" { "home" }
+
+    request = HTTP::Request.new("GET", "/")
+    create_request_and_return_io_and_context(filter_middleware, request)
+    create_request_and_return_io_and_context(kemal, request)
+
+    star_count.should eq(1)
+    slash_star_count.should eq(1)
+  end
+
   it "executes before_all filter on 404" do
     before_filter = FilterTest.new
     before_filter.modified = "false"

--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -4,14 +4,20 @@ module Kemal
     include HTTP::Handler
     INSTANCE = new
 
-    # Path used to represent wildcard filters that apply to all routes
-    private WILDCARD_PATH = "*"
+    # Path spellings that mean "every request path": `before_all` registers
+    # on "*" while `before_all "/*"` registers on "/*". Both are normalized
+    # into @global_filters at registration time and never enter the radix
+    # tree, so a path lookup can never match them a second time (#757).
+    private WILDCARD_PATHS = {"*", "/*"}
 
     @tree : Radix::Tree(Array(FilterBlock))
 
     # Hash cache for exact path filters to avoid repeated tree lookups
-    # Key format: "/#{type}/#{verb}/#{path}" (e.g., "/before/ALL/*")
+    # Key format: "/#{type}/#{verb}/#{path}" (e.g., "/before/ALL//api")
     @exact_filters : Hash(String, Array(FilterBlock))
+
+    # Global filters (`before_all` / `after_all`), keyed by "#{type}/#{verb}"
+    @global_filters : Hash(String, Array(FilterBlock))
 
     def tree
       @tree
@@ -20,12 +26,14 @@ module Kemal
     def tree=(tree : Radix::Tree(Array(FilterBlock)))
       @tree = tree
       @exact_filters = Hash(String, Array(FilterBlock)).new
+      @global_filters = Hash(String, Array(FilterBlock)).new
     end
 
     # This middleware is lazily instantiated and added to the handlers as soon as a call to `after_X` or `before_X` is made.
     def initialize
       @tree = Radix::Tree(Array(FilterBlock)).new
       @exact_filters = Hash(String, Array(FilterBlock)).new
+      @global_filters = Hash(String, Array(FilterBlock)).new
       Kemal.config.add_filter_handler(self)
     end
 
@@ -53,8 +61,22 @@ module Kemal
     # This shouldn't be called directly, it's not private because I need to call it for testing purpose since I can't call the macros in the spec.
     #
     # Registers a filter block for the given verb/path/type combination.
-    # Uses @exact_filters hash for O(1) lookup when adding multiple filters to the same path.
+    # Global paths ("*" and "/*") are stored in @global_filters, everything
+    # else goes into the radix tree with an @exact_filters hash cache for
+    # O(1) lookup when adding multiple filters to the same path.
     def _add_route_filter(verb : String, path, type, &block : HTTP::Server::Context -> _)
+      if WILDCARD_PATHS.includes?(path)
+        key = global_key(verb, type)
+
+        if filters = @global_filters[key]?
+          filters << FilterBlock.new(&block)
+        else
+          @global_filters[key] = [FilterBlock.new(&block)]
+        end
+
+        return
+      end
+
       key = radix_path(verb, path, type)
 
       if filters = @exact_filters[key]?
@@ -81,24 +103,19 @@ module Kemal
       _add_route_filter verb, path, :after, &block
     end
 
-    # Executes filters for a given path, ensuring global wildcard filters run first.
+    # Executes filters for a given path.
     #
     # Execution order:
-    # 1. Global wildcard filters ("*") - if path is not already a wildcard
-    # 2. Exact path filters - filters registered for the specific path
+    # 1. Global filters (`before_all` / `after_all`) - always run, exactly once
+    # 2. Path-specific filters - matched via radix lookup for the request path
     #
-    # This ensures that global filters (like `before_all`) always execute,
-    # while namespace-specific filters only apply to their registered paths.
+    # Global filters never enter the radix tree, so the path lookup below
+    # cannot match them again - duplicate execution is structurally impossible.
     private def call_block_for_path_type(verb : String?, path : String, type, context : HTTP::Server::Context)
-      if path != WILDCARD_PATH
-        call_block_for_exact_path_type(verb, "*", type, context)
+      if global_filters = @global_filters[global_key(verb, type)]?
+        global_filters.each &.call(context)
       end
 
-      # Executes all filter blocks registered for a specific verb/path/type combination
-      call_block_for_exact_path_type(verb, path, type, context)
-    end
-
-    private def call_block_for_exact_path_type(verb : String?, path : String, type, context : HTTP::Server::Context)
       lookup = lookup_filters_for_path_type(verb, path, type)
       if lookup.found? && lookup.payload.is_a? Array(FilterBlock)
         blocks = lookup.payload
@@ -119,6 +136,10 @@ module Kemal
 
     private def radix_path(verb : String?, path : String, type : Symbol)
       "/#{type}/#{verb}/#{path}"
+    end
+
+    private def global_key(verb : String?, type : Symbol)
+      "#{type}/#{verb}"
     end
 
     # :nodoc:


### PR DESCRIPTION
Fixes #757

### Problem

After #737, global filters lived in the radix tree alongside path-specific ones. `call_block_for_path_type` ran the `*` filters explicitly, then the radix lookup for the request path matched the same `*` catch-all again — so `before_all` blocks ran twice per request (duplicated DB/auth calls).

A related edge case: `before_all "/*"` registers on a different key than `before_all`, so `/` could miss the global filter entirely when another wildcard filter (e.g. `before_all "/api/*"`) was also registered.

### Solution

Make duplicate execution structurally impossible by separating global filters from the radix tree at registration time:

- `_add_route_filter` normalizes `"*"` and `"/*"` into a dedicated `@global_filters` hash — they never enter the radix tree
- `call_block_for_path_type` simply runs global filters first, then the radix lookup for path-specific filters; the lookup can no longer re-match a global filter
- `before_all "/*"` now behaves exactly like `before_all`, including on `/`

No dedup bookkeeping or per-request allocations needed.