### PR TITLE
Fix unhandled exception when headers were already sent to the client

### DIFF
--- a/spec/filters_spec.cr
+++ b/spec/filters_spec.cr
@@ -34,4 +34,102 @@ describe "Kemal::FilterHandler" do
     client_response.status_code.should eq(200)
     client_response.body.should eq("")
   end
+
+  context "after filters" do
+    it "does not crash when modifying headers for large responses (#759)" do
+      filter_handler = Kemal::FilterHandler.new
+      filter_handler._add_route_filter("GET", "*", :after) do |env|
+        env.response.content_type = "application/json"
+      end
+      Kemal.config.add_filter_handler(filter_handler)
+
+      # Large enough to overflow the 8KB response output buffer: the headers
+      # are flushed to the client before the after filter runs, so the header
+      # change raises. The response must still be delivered intact instead of
+      # crashing with an unhandled exception (#759).
+      body = "a" * 100_000
+
+      get "/big" do
+        body
+      end
+
+      request = HTTP::Request.new("GET", "/big")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.body.should eq(body)
+    end
+
+    it "can modify response headers for small responses" do
+      filter_handler = Kemal::FilterHandler.new
+      filter_handler._add_route_filter("GET", "*", :after) do |env|
+        env.response.content_type = "application/json"
+      end
+      Kemal.config.add_filter_handler(filter_handler)
+
+      get "/small" do
+        "ok"
+      end
+
+      request = HTTP::Request.new("GET", "/small")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.headers["Content-Type"].should eq("application/json")
+      client_response.body.should eq("ok")
+    end
+
+    it "renders 500 when an after filter raises before the headers are sent" do
+      filter_handler = Kemal::FilterHandler.new
+      filter_handler._add_route_filter("GET", "*", :after) do |_env|
+        raise "after filter error"
+      end
+      Kemal.config.add_filter_handler(filter_handler)
+
+      get "/small" do
+        "ok"
+      end
+
+      request = HTTP::Request.new("GET", "/small")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(500)
+    end
+
+    it "delivers the response as-is when an after filter raises after the headers were sent" do
+      filter_handler = Kemal::FilterHandler.new
+      filter_handler._add_route_filter("GET", "*", :after) do |_env|
+        raise "after filter error"
+      end
+      Kemal.config.add_filter_handler(filter_handler)
+
+      body = "a" * 100_000
+
+      get "/big" do
+        body
+      end
+
+      request = HTTP::Request.new("GET", "/big")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.body.should eq(body)
+    end
+
+    it "does not crash when the route already streamed the response body" do
+      filter_handler = Kemal::FilterHandler.new
+      filter_handler._add_route_filter("GET", "*", :after) do |env|
+        env.response.content_type = "application/json"
+      end
+      Kemal.config.add_filter_handler(filter_handler)
+
+      body = "b" * 100_000
+
+      get "/stream" do |env|
+        env.response.print(body)
+        ""
+      end
+
+      request = HTTP::Request.new("GET", "/stream")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.body.should eq(body)
+    end
+  end
 end

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -120,6 +120,11 @@ end
 #   # Logging
 # end
 # ```
+#
+# NOTE: Response headers must be set before the response body is written,
+# so use `before_*` filters for header changes. Once the body grows beyond
+# the output buffer the headers are flushed to the client, and modifying
+# them afterwards (e.g. in an `after_*` filter) raises an `IO::Error`.
 {% for type in ["before", "after"] %}
   {% for method in FILTER_METHODS %}
     def {{ type.id }}_{{ method.id }}(path : String = "*", &block : HTTP::Server::Context -> _)

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -122,9 +122,7 @@ end
 # ```
 #
 # NOTE: Response headers must be set before the response body is written,
-# so use `before_*` filters for header changes. Once the body grows beyond
-# the output buffer the headers are flushed to the client, and modifying
-# them afterwards (e.g. in an `after_*` filter) raises an `IO::Error`.
+# so use `before_*` filters for header changes.
 {% for type in ["before", "after"] %}
   {% for method in FILTER_METHODS %}
     def {{ type.id }}_{{ method.id }}(path : String = "*", &block : HTTP::Server::Context -> _)

--- a/src/kemal/exception_handler.cr
+++ b/src/kemal/exception_handler.cr
@@ -44,7 +44,7 @@ module Kemal
       handler : Proc(HTTP::Server::Context, Exception, String),
       status_code : Int32 = 500,
     )
-      return if context.response.closed?
+      return if context.response.closed? || context.response.headers_sent?
 
       context.response.content_type = "text/html" unless context.response.headers.has_key?("Content-Type")
       context.response.status_code = status_code
@@ -53,7 +53,7 @@ module Kemal
     end
 
     private def call_exception_with_status_code(context : HTTP::Server::Context, exception : Exception, status_code : Int32)
-      return if context.response.closed?
+      return if context.response.closed? || context.response.headers_sent?
       if !Kemal.config.error_handlers.empty? && Kemal.config.error_handlers.has_key?(status_code)
         context.response.content_type = "text/html" unless context.response.headers.has_key?("Content-Type")
         context.response.status_code = status_code
@@ -63,7 +63,7 @@ module Kemal
     end
 
     private def call_payload_too_large(context : HTTP::Server::Context, exception : Kemal::Exceptions::PayloadTooLarge)
-      return if context.response.closed?
+      return if context.response.closed? || context.response.headers_sent?
 
       context.response.content_type = "text/plain" unless context.response.headers.has_key?("Content-Type")
       context.response.status_code = 413

--- a/src/kemal/ext/response.cr
+++ b/src/kemal/ext/response.cr
@@ -1,18 +1,24 @@
-# This override collides with the new stdlib of Crystal 1.3
-# See https://github.com/kemalcr/kemal/issues/627 for more details
-{{ skip_file if compare_versions(Crystal::VERSION, "1.3.0") >= 0 }}
-
 class HTTP::Server::Response
-  class Output
-    def close
-      # ameba:disable Style/NegatedConditionsInUnless
-      unless response.wrote_headers? && !response.headers.has_key?("Content-Range")
-        response.content_length = @out_count
-      end
-
-      ensure_headers_written
-
-      previous_def
-    end
+  # Returns `true` if the response headers have already been written to the
+  # client. Once the headers are sent, the status code and headers can no
+  # longer be modified.
+  def headers_sent? : Bool
+    wrote_headers?
   end
+
+  # This override collides with the new stdlib of Crystal 1.3
+  # See https://github.com/kemalcr/kemal/issues/627 for more details
+  {% if compare_versions(Crystal::VERSION, "1.3.0") < 0 %}
+    class Output
+      def close
+        unless response.wrote_headers? && !response.headers.has_key?("Content-Range")
+          response.content_length = @out_count
+        end
+
+        ensure_headers_written
+
+        previous_def
+      end
+    end
+  {% end %}
 end

--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -51,6 +51,7 @@ module Kemal
       if Kemal.config.error_handlers.has_key?(context.response.status_code)
         raise Kemal::Exceptions::CustomException.new(context)
       end
+
       call_next(context)
       call_block_for_path_type(context.request.method, context.request.path, :after, context)
       call_block_for_path_type("ALL", context.request.path, :after, context)

--- a/src/kemal/helpers/templates.cr
+++ b/src/kemal/helpers/templates.cr
@@ -22,6 +22,10 @@ def render_404
 end
 
 def render_500(context, exception, verbosity)
+  # If the headers were already sent, the status code and headers can no
+  # longer be changed and a meaningful error page can't be delivered.
+  return context if context.response.headers_sent?
+
   context.response.content_type = "text/html"
   context.response.status_code = 500
 


### PR DESCRIPTION
Fixes #759

## Problem

Changing response headers in an `after_all` filter raises `Headers already sent (IO::Error)` when the response body exceeds the 8KB output buffer, because Crystal flushes the headers to the socket mid-write. The exception handler made it worse by trying to render a 500 page, which also sets headers and raises again, producing an unhandled exception in the logs and a half-written response.

## Solution

Headers must be set before the body is written, so `before_*` filters are the right place for header changes. This PR doesn't try to make header changes in after filters work (see the discussion below), it fixes the secondary crash instead:

- Added `HTTP::Server::Response#headers_sent?` and guarded `render_500`, the custom error handler paths and the payload-too-large handler with it. When the headers are already on the wire, the exception handler now delivers the response as-is instead of crashing with a second exception.
- The `headers_sent?` helper is available on all Crystal versions; the old `Output#close` override is still only compiled on Crystal < 1.3.
- Documented in the filter DSL docs that header changes belong in `before_*` filters and why.

An earlier revision of this PR deferred writing the route's response body until the after filters had run, so header changes in after filters would work for any response size. That approach was dropped after review feedback: it can't cover handlers that write directly to the response IO (e.g. `send_file`), so it would have fixed the inconsistency only partially. See the discussion with @straight-shoota below.

## Behavior changes

- An exception raised in an after filter before the headers are sent (small responses) renders a proper 500 page, as before.
- An exception raised after the headers are sent (large responses) no longer produces an unhandled exception in the logs; the response is delivered intact.
