### PR TITLE
Revert "Update ameba version to 1.6.4 in shard.yml and CI workflow"

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: 1.6.4
+    branch: master
 
 crystal: ">= 1.12.0"
 


### PR DESCRIPTION
This reverts commit 5e603962be3b15149164856036a14268a37271b3.

Fixes CI on nightlies