### PR TITLE
[Security] Fix only/exclude scoping for auth middleware (all methods + path prefixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `only` / `exclude` opt-in matching for all HTTP methods (`"*"`) and path prefixes (`"/*"`). Defaults remain GET + exact path. Clarified docs and the basic-auth custom handler example. Thanks @hahwul for the report. Thanks @sdogruyol :pray:
+
 - ***(SECURITY)*** Close the HTTP connection after a rejected WebSocket upgrade (403). Without `Connection: close`, a compound `Connection: keep-alive, Upgrade` request that fails Origin validation left the connection keep-alive, so a request pipelined behind a reverse proxy that tunnels upgrades could bypass the proxy’s access controls (WebSocket connection smuggling). Malformed `Origin` values that previously raised from `URI.parse` now reject with 403 instead of 500.
 
 # 1.12.0 (21-07-2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Add `only` / `exclude` opt-in matching for all HTTP methods (`"*"`) and path prefixes (`"/*"`). Defaults remain GET + exact path. Clarified docs and the basic-auth custom handler example. Thanks @hahwul for the report. Thanks @sdogruyol :pray:
+- Fix `only` / `exclude` with method `"*"` over-matching every path: Radix treats `*` as a glob, so the all-methods marker is stored under a safe sentinel. Thanks @hahwul for the report. Thanks @sdogruyol :pray::
 
 - ***(SECURITY)*** Close the HTTP connection after a rejected WebSocket upgrade (403). Without `Connection: close`, a compound `Connection: keep-alive, Upgrade` request that fails Origin validation left the connection keep-alive, so a request pipelined behind a reverse proxy that tunnels upgrades could bypass the proxy’s access controls (WebSocket connection smuggling). Malformed `Origin` values that previously raised from `URI.parse` now reject with 403 instead of 500.
 

--- a/examples/http-basic-auth/custom-handler.cr
+++ b/examples/http-basic-auth/custom-handler.cr
@@ -2,9 +2,11 @@ require "kemal-basic-auth"
 
 # Create a custom authentication handler by inheriting from Kemal::BasicAuth::Handler
 class CustomAuthHandler < Kemal::BasicAuth::Handler
-  # Specify which routes should be protected by basic auth
-  # In this case, only /dashboard and /admin routes will require authentication
-  only ["/dashboard", "/admin"]
+  # Protect /dashboard and /admin (and their subpaths) for every HTTP method.
+  # `only` defaults to GET + exact path — insufficient for auth. Use "/*" for
+  # prefix matching and "*" for all methods. For subtree middleware without
+  # method filtering, prefer: use "/admin", AuthHandler.new
+  only ["/dashboard/*", "/admin/*"], "*"
 
   # Override the call method to implement custom authentication logic
   def call(context)

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -67,6 +67,66 @@ class PostOnlyHandlerPercentW < Kemal::Handler
   end
 end
 
+class AllMethodsOnlyHandler < Kemal::Handler
+  only ["/only"], "*"
+
+  def call(env)
+    return call_next(env) unless only_match?(env)
+    env.response.print "Only"
+    call_next env
+  end
+end
+
+class PrefixOnlyHandler < Kemal::Handler
+  only ["/admin/*"]
+
+  def call(env)
+    return call_next(env) unless only_match?(env)
+    env.response.print "Only"
+    call_next env
+  end
+end
+
+class PrefixAllMethodsOnlyHandler < Kemal::Handler
+  only ["/admin/*"], "*"
+
+  def call(env)
+    return call_next(env) unless only_match?(env)
+    env.response.print "Only"
+    call_next env
+  end
+end
+
+class PrefixAllMethodsExcludeHandler < Kemal::Handler
+  exclude ["/public/*"], "*"
+
+  def call(env)
+    return call_next(env) if exclude_match?(env)
+    env.response.print "Secure"
+    call_next env
+  end
+end
+
+class AdminPrefixHandler < Kemal::Handler
+  only ["/admin/*"], "*"
+
+  def call(env)
+    return call_next(env) unless only_match?(env)
+    env.response.print "Admin"
+    call_next env
+  end
+end
+
+class ApiPrefixHandler < Kemal::Handler
+  only ["/api/*"], "*"
+
+  def call(env)
+    return call_next(env) unless only_match?(env)
+    env.response.print "Api"
+    call_next env
+  end
+end
+
 describe "Handler" do
   it "adds custom handler before before_*" do
     filter_middleware = Kemal::FilterHandler.new
@@ -157,5 +217,75 @@ describe "Handler" do
     exclude_handler = ExcludeHandlerPercentW.new
     Kemal.config.handlers = [post_only_handler, exclude_handler]
     Kemal.config.handlers.should eq [post_only_handler, exclude_handler]
+  end
+
+  it "runs only_routes for all methods when method is *" do
+    post "/only" do
+      "Post"
+    end
+    delete "/only" do
+      "Delete"
+    end
+    use AllMethodsOnlyHandler.new
+
+    post_response = call_request_on_app(HTTP::Request.new("POST", "/only"))
+    post_response.body.should eq "OnlyPost"
+
+    delete_response = call_request_on_app(HTTP::Request.new("DELETE", "/only"))
+    delete_response.body.should eq "OnlyDelete"
+  end
+
+  it "runs only_routes for path prefixes ending with /*" do
+    get "/admin" do
+      "Root"
+    end
+    get "/admin/users" do
+      "Users"
+    end
+    get "/adminx" do
+      "Other"
+    end
+    use PrefixOnlyHandler.new
+
+    call_request_on_app(HTTP::Request.new("GET", "/admin")).body.should eq "OnlyRoot"
+    call_request_on_app(HTTP::Request.new("GET", "/admin/users")).body.should eq "OnlyUsers"
+    call_request_on_app(HTTP::Request.new("GET", "/adminx")).body.should eq "Other"
+  end
+
+  it "runs only_routes for path prefixes on all methods" do
+    post "/admin/users" do
+      "Users"
+    end
+    use PrefixAllMethodsOnlyHandler.new
+
+    response = call_request_on_app(HTTP::Request.new("POST", "/admin/users"))
+    response.body.should eq "OnlyUsers"
+  end
+
+  it "skips exclude_routes for path prefixes on all methods" do
+    get "/public/logo.png" do
+      "Asset"
+    end
+    post "/secret" do
+      "Secret"
+    end
+    use PrefixAllMethodsExcludeHandler.new
+
+    call_request_on_app(HTTP::Request.new("GET", "/public/logo.png")).body.should eq "Asset"
+    call_request_on_app(HTTP::Request.new("POST", "/secret")).body.should eq "SecureSecret"
+  end
+
+  it "scopes path prefixes to the handler class" do
+    get "/admin/users" do
+      "Users"
+    end
+    get "/api/users" do
+      "Users"
+    end
+    use AdminPrefixHandler.new
+    use ApiPrefixHandler.new
+
+    call_request_on_app(HTTP::Request.new("GET", "/admin/users")).body.should eq "AdminUsers"
+    call_request_on_app(HTTP::Request.new("GET", "/api/users")).body.should eq "ApiUsers"
   end
 end

--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -77,6 +77,26 @@ class AllMethodsOnlyHandler < Kemal::Handler
   end
 end
 
+class ExactAllMethodsOnlyHandler < Kemal::Handler
+  only ["/admin"], "*"
+
+  def call(env)
+    return call_next(env) unless only_match?(env)
+    env.response.print "Only"
+    call_next env
+  end
+end
+
+class ExactAllMethodsExcludeHandler < Kemal::Handler
+  exclude ["/public"], "*"
+
+  def call(env)
+    return call_next(env) if exclude_match?(env)
+    env.response.print "Secure"
+    call_next env
+  end
+end
+
 class PrefixOnlyHandler < Kemal::Handler
   only ["/admin/*"]
 
@@ -233,6 +253,44 @@ describe "Handler" do
 
     delete_response = call_request_on_app(HTTP::Request.new("DELETE", "/only"))
     delete_response.body.should eq "OnlyDelete"
+  end
+
+  it "keeps exact only_routes with method * path-scoped" do
+    get "/admin" do
+      "Admin"
+    end
+    post "/admin" do
+      "Admin"
+    end
+    get "/admin/users" do
+      "Users"
+    end
+    get "/other" do
+      "Other"
+    end
+    use ExactAllMethodsOnlyHandler.new
+
+    call_request_on_app(HTTP::Request.new("GET", "/admin")).body.should eq "OnlyAdmin"
+    call_request_on_app(HTTP::Request.new("POST", "/admin")).body.should eq "OnlyAdmin"
+    call_request_on_app(HTTP::Request.new("GET", "/admin/users")).body.should eq "Users"
+    call_request_on_app(HTTP::Request.new("GET", "/other")).body.should eq "Other"
+  end
+
+  it "keeps exact exclude_routes with method * path-scoped" do
+    get "/public" do
+      "Public"
+    end
+    get "/public/logo.png" do
+      "Asset"
+    end
+    post "/secret" do
+      "Secret"
+    end
+    use ExactAllMethodsExcludeHandler.new
+
+    call_request_on_app(HTTP::Request.new("GET", "/public")).body.should eq "Public"
+    call_request_on_app(HTTP::Request.new("GET", "/public/logo.png")).body.should eq "SecureAsset"
+    call_request_on_app(HTTP::Request.new("POST", "/secret")).body.should eq "SecureSecret"
   end
 
   it "runs only_routes for path prefixes ending with /*" do

--- a/src/kemal/handler.cr
+++ b/src/kemal/handler.cr
@@ -18,12 +18,26 @@ module Kemal
   module HandlerInterface
     include HTTP::Handler
 
+    # Public marker for "match every HTTP method" in `only` / `exclude`.
+    ALL_METHODS = "*"
+
+    # :nodoc:
+    # Radix treats path segments starting with `*` as globs. The public
+    # `ALL_METHODS` marker is rewritten to this sentinel in exact-route keys
+    # so `only ["/admin"], "*"` stays path-exact.
+    ALL_METHODS_KEY = "__ALL__"
+
     macro included
       @@only_routes_tree = Radix::Tree(String).new
       @@exclude_routes_tree = Radix::Tree(String).new
       # class_name => [{method, prefix}, ...] — grouped to avoid scanning other handlers' rules
       @@only_path_prefixes = {} of String => Array({String, String})
       @@exclude_path_prefixes = {} of String => Array({String, String})
+    end
+
+    # :nodoc:
+    def self.radix_method(method : String) : String
+      method == ALL_METHODS ? ALL_METHODS_KEY : method
     end
 
     # Restricts the handler to the given paths.
@@ -58,13 +72,17 @@ module Kemal
     # :nodoc:
     macro __add_handler_routes(class_name, paths, method, tree, prefixes)
       %class_name = {{ class_name }}
-      %class_name_method = "#{%class_name}/#{{{ method }}}"
+      %method = {{ method }}
+      %radix_method = ::Kemal::HandlerInterface.radix_method(%method)
+      %class_name_method = "#{%class_name}/#{%radix_method}"
       ({{ paths }}).each do |path|
         if path.ends_with?("/*")
           %prefix = path[0...-2]
-          ({{ prefixes }}[%class_name] ||= [] of {String, String}) << { {{ method }}, %prefix }
+          # Keep the public method marker (`"*"` / `"GET"` / …) for prefix rules;
+          # only exact-route radix keys need the glob-safe sentinel.
+          ({{ prefixes }}[%class_name] ||= [] of {String, String}) << { %method, %prefix }
         else
-          {{ tree }}.add %class_name_method + path, '/' + {{ method }} + path
+          {{ tree }}.add %class_name_method + path, '/' + %method + path
         end
       end
     end
@@ -121,11 +139,11 @@ module Kemal
       class_name = self.class.to_s
 
       return true if tree.find(radix_path(method, path)).found?
-      return true if tree.find(radix_path("*", path)).found?
+      return true if tree.find(radix_path(ALL_METHODS_KEY, path)).found?
 
       if rules = prefixes[class_name]?
         return true if rules.any? do |(rule_method, prefix)|
-                         (rule_method == "*" || rule_method == method) && Utils.matches_path_prefix?(prefix, path)
+                         (rule_method == ALL_METHODS || rule_method == method) && Utils.matches_path_prefix?(prefix, path)
                        end
       end
 

--- a/src/kemal/handler.cr
+++ b/src/kemal/handler.cr
@@ -4,6 +4,13 @@ module Kemal
   # More specifically, `only`, `only_match?`, `exclude`, `exclude_match?`
   # allows one to define the conditional execution of custom handlers.
   #
+  # By default, `only` / `exclude` match a single HTTP method (`GET`) and an
+  # exact path. Pass `"*"` as the method to match all methods, and end a path
+  # with `"/*"` for prefix matching (same rules as `PathHandler`).
+  #
+  # For middleware that should run for an entire path subtree on every method,
+  # prefer `use "/admin", MyHandler.new` instead of `only`.
+  #
   # To use, simply `include` it within your type.
   #
   # It is an implementation of `HTTP::Handler` and can be used anywhere that
@@ -14,21 +21,51 @@ module Kemal
     macro included
       @@only_routes_tree = Radix::Tree(String).new
       @@exclude_routes_tree = Radix::Tree(String).new
+      # class_name => [{method, prefix}, ...] — grouped to avoid scanning other handlers' rules
+      @@only_path_prefixes = {} of String => Array({String, String})
+      @@exclude_path_prefixes = {} of String => Array({String, String})
     end
 
+    # Restricts the handler to the given paths.
+    #
+    # Defaults to exact path match for `GET` only. Use `"*"` as *method* to
+    # match all HTTP methods. Paths ending with `"/*"` match that prefix
+    # (e.g. `"/admin/*"` matches `/admin` and `/admin/users`).
+    #
+    # ```
+    # only ["/admin"]         # GET /admin
+    # only ["/admin"], "POST" # POST /admin
+    # only ["/admin"], "*"    # any method, exact /admin
+    # only ["/admin/*"], "*"  # any method under /admin
+    # ```
     macro only(paths, method = "GET")
-      class_name = {{ @type.name }}
-      class_name_method = "#{class_name}/#{{{ method }}}"
-      ({{ paths }}).each do |path|
-        @@only_routes_tree.add class_name_method + path, '/' + {{ method }} + path
-      end
+      ::Kemal::HandlerInterface.__add_handler_routes({{ @type.stringify }}, {{ paths }}, {{ method }}, @@only_routes_tree, @@only_path_prefixes)
     end
 
+    # Excludes the handler from the given paths.
+    #
+    # Defaults to exact path match for `GET` only. Use `"*"` as *method* to
+    # match all HTTP methods. Paths ending with `"/*"` match that prefix.
+    #
+    # ```
+    # exclude ["/public"]
+    # exclude ["/assets/*"], "*"
+    # ```
     macro exclude(paths, method = "GET")
-      class_name = {{ @type.name }}
-      class_name_method = "#{class_name}/#{{{ method }}}"
+      ::Kemal::HandlerInterface.__add_handler_routes({{ @type.stringify }}, {{ paths }}, {{ method }}, @@exclude_routes_tree, @@exclude_path_prefixes)
+    end
+
+    # :nodoc:
+    macro __add_handler_routes(class_name, paths, method, tree, prefixes)
+      %class_name = {{ class_name }}
+      %class_name_method = "#{%class_name}/#{{{ method }}}"
       ({{ paths }}).each do |path|
-        @@exclude_routes_tree.add class_name_method + path, '/' + {{ method }} + path
+        if path.ends_with?("/*")
+          %prefix = path[0...-2]
+          ({{ prefixes }}[%class_name] ||= [] of {String, String}) << { {{ method }}, %prefix }
+        else
+          {{ tree }}.add %class_name_method + path, '/' + {{ method }} + path
+        end
       end
     end
 
@@ -54,7 +91,7 @@ module Kemal
     # end
     # ```
     def only_match?(env : HTTP::Server::Context)
-      @@only_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
+      matches_scoped_routes?(env, @@only_routes_tree, @@only_path_prefixes)
     end
 
     # Processes the path based on `exclude` paths which is a `Array(String)`.
@@ -75,7 +112,24 @@ module Kemal
     # end
     # ```
     def exclude_match?(env : HTTP::Server::Context)
-      @@exclude_routes_tree.find(radix_path(env.request.method, env.request.path)).found?
+      matches_scoped_routes?(env, @@exclude_routes_tree, @@exclude_path_prefixes)
+    end
+
+    private def matches_scoped_routes?(env : HTTP::Server::Context, tree : Radix::Tree(String), prefixes : Hash(String, Array({String, String}))) : Bool
+      method = env.request.method
+      path = env.request.path
+      class_name = self.class.to_s
+
+      return true if tree.find(radix_path(method, path)).found?
+      return true if tree.find(radix_path("*", path)).found?
+
+      if rules = prefixes[class_name]?
+        return true if rules.any? do |(rule_method, prefix)|
+                         (rule_method == "*" || rule_method == method) && Utils.matches_path_prefix?(prefix, path)
+                       end
+      end
+
+      false
     end
 
     private def radix_path(method : String, path : String)

--- a/src/kemal/helpers/utils.cr
+++ b/src/kemal/helpers/utils.cr
@@ -9,5 +9,14 @@ module Kemal
     def self.zip_types(path : String) # https://github.com/h5bp/server-configs-nginx/blob/master/nginx.conf
       ZIP_TYPES.includes? File.extname(path)
     end
+
+    # Exact prefix, or prefix followed by `/`. `"/"`, and `""` match all paths.
+    def self.matches_path_prefix?(prefix : String, path : String) : Bool
+      return true if prefix.in?("/", "")
+
+      return true if path == prefix
+
+      path.starts_with?("#{prefix}/")
+    end
   end
 end

--- a/src/kemal/path_handler.cr
+++ b/src/kemal/path_handler.cr
@@ -20,27 +20,13 @@ module Kemal
     end
 
     def call(context : HTTP::Server::Context)
-      if matches_prefix?(context.request.path)
+      if Utils.matches_path_prefix?(@path_prefix, context.request.path)
         # Set next handler for the wrapped handler
         @handler.next = self.next
         @handler.call(context)
       else
         call_next(context)
       end
-    end
-
-    # Checks if the request path matches the handler's path prefix.
-    # - "/" or "" matches all paths
-    # - "/api" matches "/api" and "/api/*"
-    # - "/api" does NOT match "/apiv2"
-    private def matches_prefix?(path : String) : Bool
-      return true if path_prefix.in?("/", "")
-
-      # Exact match
-      return true if path == path_prefix
-
-      # Prefix match (must be followed by /)
-      path.starts_with?("#{path_prefix}/")
     end
   end
 end


### PR DESCRIPTION
## Summary

`Kemal::Handler` `only` / `exclude` previously matched **GET + exact path only**. That made auth-style middleware easy to misconfigure: a handler like `only ["/admin"]` silently skipped `POST`/`PUT`/`DELETE` and subpaths such as `/admin/users`.

This PR makes secure scoping opt-in and explicit, without changing defaults:

- `"*"` — match all HTTP methods
- `"/*"` — match a path prefix (same rules as `PathHandler`)
- Defaults remain **GET + exact path**

Also fixes a follow-up issue where `only ["/admin"], "*"` over-matched every path because Radix treats `*` as a glob catch-all. The public `"*"` API is unchanged; exact-route keys now use an internal sentinel.

Thanks **@hahwul** for the report :pray:

## Example

```crystal
class AuthHandler < Kemal::Handler
  only ["/admin/*"], "*"

  def call(env)
    return call_next(env) unless only_match?(env)
    # authenticate…
  end
end
```

For subtree middleware without method filtering, prefer:

```crystal
use "/admin", AuthHandler.new
```