### PR TITLE
[Security] Fix CSWSH: same-origin WebSocket Origin check by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Unreleased
 
+- ***(SECURITY)*** WebSocket Origin validation is same-origin by default (CSWSH). An empty `websocket_allowed_origins` now requires `Origin` to match the request `Host` (scheme taken from `Origin`, so reverse-proxy TLS termination keeps working). Missing or empty `Origin` is rejected with 403. Set `Kemal.config.websocket_allowed_origins = ["*"]` to opt into allowing any origin, including requests without `Origin`. Explicit allowlists behave as before.
+
+```crystal
+# Default: same-origin (secure)
+# Kemal.config.websocket_allowed_origins = [] of String
+
+# Explicit allowlist
+Kemal.config.websocket_allowed_origins = ["https://myapp.com", "http://localhost:3000"]
+
+# Previous allow-all behavior (opt-in)
+Kemal.config.websocket_allowed_origins = ["*"]
+```
+
 - ***(SECURITY)*** Prevent SSE injection in `Kemal::EventStream`: reject newlines in `event`/`id`, normalize CR/LF in `data`/`comment`. Thanks @hahwul for the report. Thanks @sdogruyol for the fix :pray:
 - Fix URL params being decoded again on every request when route lookup results are cached. Thanks @hahwul for the report. Thanks @sdogruyol for the fix :pray:
 

--- a/spec/router_spec.cr
+++ b/spec/router_spec.cr
@@ -384,6 +384,8 @@ describe "Kemal::Router" do
         "Connection"            => "Upgrade",
         "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
         "Sec-WebSocket-Version" => "13",
+        "Host"                  => "localhost",
+        "Origin"                => "http://localhost",
       }
       request = HTTP::Request.new("GET", "/ws/chat", headers)
 
@@ -405,6 +407,8 @@ describe "Kemal::Router" do
         "Connection"            => "Upgrade",
         "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
         "Sec-WebSocket-Version" => "13",
+        "Host"                  => "localhost",
+        "Origin"                => "http://localhost",
       }
       request = HTTP::Request.new("GET", "/ws/room/123", headers)
 

--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -81,12 +81,8 @@ describe "Kemal::WebSocketHandler" do
     handler = Kemal::WebSocketHandler::INSTANCE
     ws("/", &.send("Match"))
     ws("/no_match", &.send("No Match"))
-    headers = HTTP::Headers{
-      "Upgrade"               => "websocket",
-      "Connection"            => "Upgrade",
-      "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
-      "Sec-WebSocket-Version" => "13",
-    }
+    headers = ws_upgrade_headers_for_origin("http://localhost")
+    headers["Host"] = "localhost"
     request = HTTP::Request.new("GET", "/", headers)
 
     io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
@@ -96,12 +92,8 @@ describe "Kemal::WebSocketHandler" do
   it "fetches named url parameters" do
     handler = Kemal::WebSocketHandler::INSTANCE
     ws "/:id" { |_, context| context.ws_route_lookup.params["id"] }
-    headers = HTTP::Headers{
-      "Upgrade"               => "websocket",
-      "Connection"            => "Upgrade",
-      "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
-      "Sec-WebSocket-Version" => "13",
-    }
+    headers = ws_upgrade_headers_for_origin("http://localhost")
+    headers["Host"] = "localhost"
     request = HTTP::Request.new("GET", "/1234", headers)
     io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
     io_with_context.to_s.should eq("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n")
@@ -167,6 +159,115 @@ describe "Kemal::WebSocketHandler" do
       handler = Kemal::WebSocketHandler::INSTANCE
       ws("/", &.send("x"))
       request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("https://example.com:443"))
+      io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
+      io_with_context.to_s.should contain("101 Switching Protocols")
+    end
+
+    it "allows same origin by default (Origin matches Host)" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/", &.send("ok")
+      headers = ws_upgrade_headers_for_origin("http://localhost")
+      headers["Host"] = "localhost"
+      request = HTTP::Request.new("GET", "/", headers)
+      io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
+      io_with_context.to_s.should contain("101 Switching Protocols")
+    end
+
+    it "allows https Origin against Host when TLS is terminated upstream" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/", &.send("ok")
+      headers = ws_upgrade_headers_for_origin("https://app.example.com")
+      headers["Host"] = "app.example.com"
+      request = HTTP::Request.new("GET", "/", headers)
+      io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
+      io_with_context.to_s.should contain("101 Switching Protocols")
+    end
+
+    it "allows same origin with non-default port" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/", &.send("ok")
+      headers = ws_upgrade_headers_for_origin("http://localhost:3000")
+      headers["Host"] = "localhost:3000"
+      request = HTTP::Request.new("GET", "/", headers)
+      io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
+      io_with_context.to_s.should contain("101 Switching Protocols")
+    end
+
+    it "rejects 403 when default config and Origin port does not match Host" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      headers = ws_upgrade_headers_for_origin("http://localhost:3000")
+      headers["Host"] = "localhost"
+      request = HTTP::Request.new("GET", "/", headers)
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
+    end
+
+    it "rejects 403 when default config and Origin does not match Host" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      headers = ws_upgrade_headers_for_origin("https://evil.com")
+      headers["Host"] = "localhost"
+      request = HTTP::Request.new("GET", "/", headers)
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
+    end
+
+    it "rejects 403 when default config and Origin is missing" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      headers = ws_upgrade_headers_for_origin
+      headers["Host"] = "localhost"
+      request = HTTP::Request.new("GET", "/", headers)
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
+    end
+
+    it "rejects 403 when default config and Host is missing" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("http://localhost"))
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
+    end
+
+    it "rejects 403 when Origin is empty string" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      headers = ws_upgrade_headers_for_origin("")
+      headers["Host"] = "localhost"
+      request = HTTP::Request.new("GET", "/", headers)
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
+    end
+
+    it "rejects 403 for opaque null Origin under default same-origin policy" do
+      Kemal.config.websocket_allowed_origins = [] of String
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      headers = ws_upgrade_headers_for_origin("null")
+      headers["Host"] = "localhost"
+      request = HTTP::Request.new("GET", "/", headers)
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
+    end
+
+    it "allows wildcard origin when '*' is in allowlist" do
+      Kemal.config.websocket_allowed_origins = ["*"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/", &.send("ok")
+      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("https://anything.com"))
+      io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
+      io_with_context.to_s.should contain("101 Switching Protocols")
+    end
+
+    it "allows missing Origin when '*' is in allowlist" do
+      Kemal.config.websocket_allowed_origins = ["*"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/", &.send("ok")
+      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin)
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
       io_with_context.to_s.should contain("101 Switching Protocols")
     end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -29,10 +29,19 @@ module Kemal
     property max_route_cache_size : Int32
     property max_request_body_size : Int32
     property max_multipart_form_field_size : Int32
-    # When non-empty, WebSocket upgrade requests must send an `Origin` header that matches
-    # one of these values (after normalization: scheme/host/port only). Entries use the
-    # serialized origin form, e.g. `"https://example.com"` or `"http://localhost:3000"`.
-    # Use `"null"` to allow the browser's opaque `"null"` origin.
+    # WebSocket Origin policy for upgrade requests.
+    #
+    # - Empty (default): same-origin — `Origin` must match the request `Host` (scheme is
+    #   taken from `Origin`, so TLS termination in front of Kemal still works). Missing or
+    #   empty `Origin` is rejected with 403.
+    # - Non-empty allowlist: `Origin` must match one of the entries after normalization
+    #   (scheme/host/port only). Missing `Origin` is rejected.
+    # - Include `"*"` to allow any origin, including requests without `Origin` (previous
+    #   allow-all behavior).
+    # - Use `"null"` to allow the browser's opaque `"null"` origin.
+    #
+    # Entries use the serialized origin form, e.g. `"https://example.com"` or
+    # `"http://localhost:3000"`.
     property websocket_allowed_origins : Array(String)
 
     def initialize

--- a/src/kemal/websocket_handler.cr
+++ b/src/kemal/websocket_handler.cr
@@ -44,7 +44,9 @@ module Kemal
 
     private def websocket_origin_allowed?(request : HTTP::Request) : Bool
       allowed = Kemal.config.websocket_allowed_origins
-      return true if allowed.empty?
+
+      # Opt-in escape hatch for the previous allow-all behavior (including missing Origin).
+      return true if allowed.includes?("*")
 
       origin_header = request.headers["Origin"]?
       return false if !origin_header || origin_header.empty?
@@ -52,7 +54,29 @@ module Kemal
       actual = normalize_websocket_origin(origin_header)
       return false unless actual
 
+      if allowed.empty?
+        return websocket_same_origin?(request, actual)
+      end
+
       allowed.any? { |entry| normalize_websocket_origin(entry) == actual }
+    end
+
+    # Same-origin: Origin's host[:port] must match the request Host header.
+    # Scheme is taken from the (already normalized) Origin so TLS termination in front of
+    # Kemal still works — Kemal.config.scheme would be "http" in that setup.
+    private def websocket_same_origin?(request : HTTP::Request, actual : String) : Bool
+      return false if actual == "null"
+
+      host = request.headers["Host"]?
+      return false if !host || host.empty?
+
+      scheme = URI.parse(actual).scheme
+      return false if !scheme || scheme.empty?
+
+      expected = normalize_websocket_origin("#{scheme}://#{host}")
+      return false unless expected
+
+      actual == expected
     end
 
     private def normalize_websocket_origin(origin : String) : String?


### PR DESCRIPTION
### Summary
This PR fixes Cross-Site WebSocket Hijacking (CSWSH) by making WebSocket `Origin` validation **secure by default**.

Previously, an empty `Kemal.config.websocket_allowed_origins` (the default) accepted **all** origins. A malicious site could open a WebSocket to a Kemal app from a victim’s browser; cookies were still sent with the handshake, so cookie-authenticated sockets were exposed.

#### New behavior

| `websocket_allowed_origins` | Policy |
| --- | --- |
| `[]` (default) | **Same-origin**: `Origin` must match the request `Host`. Missing/empty/`null` Origin → `403 Forbidden`. |
| Explicit list | Unchanged: Origin must match an entry after normalization. Missing Origin → `403`. |
| Includes `"*"` | Opt-in allow-all (previous default), including requests **without** `Origin` (curl/wscat/native clients). |

Same-origin matching uses the **scheme from `Origin`** and the **host/port from `Host`**. That way TLS termination in front of Kemal still works (`Origin: https://app.example.com` + `Host: app.example.com` succeeds even when Kemal itself is plain HTTP).

```crystal
# Default — same-origin (secure)
# Kemal.config.websocket_allowed_origins = [] of String

# Cross-origin frontend
Kemal.config.websocket_allowed_origins = ["https://myapp.com", "http://localhost:3000"]

# Previous allow-all behavior (explicit opt-in)
Kemal.config.websocket_allowed_origins = ["*"]
```

No Config property type changes. `normalize_websocket_origin` / `reject_websocket_forbidden!` are unchanged in role; same-origin logic lives next to the existing allowlist check in `WebSocketHandler`.

### Alternate Designs

1. **Keep empty = allow-all, document the risk** — Rejected. That leaves CSWSH as the default for every app that never sets the allowlist.
2. **Compare against `Kemal.config.scheme` + `Host`** — Rejected. Under a reverse-proxy TLS terminator `config.scheme` is usually `"http"` while the browser sends `https://…`, causing false `403`s for legitimate same-site clients.
3. **Require an explicit allowlist always (no same-origin default)** — Rejected. Too breaking for the common same-page WebSocket case; Rails/Phoenix/Spring all treat same-origin as the safe default.
4. **Chosen: same-origin by default + allowlist + `"*"` escape hatch** — Matches Action Cable / Phoenix / Spring posture, keeps same-origin browser apps working, and gives a one-line rollback for non-browser clients.

### Benefits

- Closes the CSWSH gap for cookie-backed WebSockets without requiring every app to discover and configure an allowlist first.
- Proxy-friendly same-origin check (scheme from `Origin`, authority from `Host`).
- Clear migration path: cross-origin SPAs set an allowlist; tools that omit `Origin` use `["*"]`.
- Documented in Config comments and `CHANGELOG` (Unreleased).

### Possible Drawbacks

- **Behavior change (security-motivated):** apps that relied on empty allowlist = allow-all will start seeing `403` for:
  - cross-origin browser clients, or
  - clients that send no `Origin` (curl, wscat, many native clients).
- Mitigation is one line: set `websocket_allowed_origins` to the real origins, or `["*"]` if the old open policy is intentional.
- Same-origin browser apps and apps that already configured an allowlist are unaffected.
- Origin checks only mitigate **browser** CSWSH; native clients can forge `Origin`. Authentication on the socket remains necessary.