### PR TITLE
[Security] Close connection after rejected WebSocket upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- ***(SECURITY)*** Close the HTTP connection after a rejected WebSocket upgrade (403). Without `Connection: close`, a compound `Connection: keep-alive, Upgrade` request that fails Origin validation left the connection keep-alive, so a request pipelined behind a reverse proxy that tunnels upgrades could bypass the proxy’s access controls (WebSocket connection smuggling). Malformed `Origin` values that previously raised from `URI.parse` now reject with 403 instead of 500.
+
 # 1.12.0 (21-07-2026)
 
 - Crystal 1.21.0 support :tada:

--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "socket"
 
 def ws_upgrade_headers_for_origin(origin : String? = nil)
   h = HTTP::Headers{
@@ -9,6 +10,51 @@ def ws_upgrade_headers_for_origin(origin : String? = nil)
   }
   h["Origin"] = origin if origin
   h
+end
+
+def call_ws_handler_response(handler, request) : HTTP::Client::Response
+  io = IO::Memory.new
+  response = HTTP::Server::Response.new(io)
+  context = HTTP::Server::Context.new(request, response)
+  handler.call(context)
+  response.close
+  io.rewind
+  HTTP::Client::Response.from_io(io, decompress: false)
+end
+
+def assert_websocket_forbidden_closed(response : HTTP::Client::Response)
+  response.status_code.should eq(403)
+  response.body.should eq("Forbidden")
+  response.headers["Connection"]?.try(&.downcase).should eq("close")
+end
+
+# Raw TCP exchange against a live HTTP::Server (needed to exercise Crystal keep-alive).
+def raw_http_exchange(host : String, port : Int32, payload : String, read_seconds = 1) : String
+  socket = nil.as(TCPSocket?)
+  20.times do
+    socket = TCPSocket.new(host, port) rescue nil
+    break if socket
+    sleep 10.milliseconds
+  end
+  raise "server did not accept connections" unless socket
+
+  socket.write(payload.to_slice)
+  socket.flush
+  socket.read_timeout = read_seconds.seconds
+  data = read_socket_until_timeout(socket)
+  socket.close
+  data
+end
+
+def read_socket_until_timeout(socket : TCPSocket) : String
+  data = IO::Memory.new
+  buffer = Bytes.new(8192)
+  while (n = socket.read(buffer)) > 0
+    data.write(buffer[0, n])
+  end
+  data.to_s
+rescue IO::TimeoutError
+  data.to_s
 end
 
 describe "Kemal::WebSocketHandler" do
@@ -67,13 +113,7 @@ describe "Kemal::WebSocketHandler" do
     ws "/" { }
     get "/" { "get" }
     request = HTTP::Request.new("GET", "/")
-    io = IO::Memory.new
-    response = HTTP::Server::Response.new(io)
-    context = HTTP::Server::Context.new(request, response)
-    handler.call(context)
-    response.close
-    io.rewind
-    client_response = HTTP::Client::Response.from_io(io, decompress: false)
+    client_response = call_ws_handler_response(handler, request)
     client_response.body.should eq("get")
   end
 
@@ -83,15 +123,7 @@ describe "Kemal::WebSocketHandler" do
       handler = Kemal::WebSocketHandler::INSTANCE
       ws "/" { }
       request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin)
-      io = IO::Memory.new
-      response = HTTP::Server::Response.new(io)
-      context = HTTP::Server::Context.new(request, response)
-      handler.call(context)
-      response.close
-      io.rewind
-      client_response = HTTP::Client::Response.from_io(io, decompress: false)
-      client_response.status_code.should eq(403)
-      client_response.body.should eq("Forbidden")
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
     end
 
     it "rejects 403 when Origin is not in allowlist" do
@@ -99,14 +131,25 @@ describe "Kemal::WebSocketHandler" do
       handler = Kemal::WebSocketHandler::INSTANCE
       ws "/" { }
       request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("https://evil.example"))
-      io = IO::Memory.new
-      response = HTTP::Server::Response.new(io)
-      context = HTTP::Server::Context.new(request, response)
-      handler.call(context)
-      response.close
-      io.rewind
-      client_response = HTTP::Client::Response.from_io(io, decompress: false)
-      client_response.status_code.should eq(403)
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
+    end
+
+    it "sets Connection: close on Origin rejection with compound Connection token" do
+      Kemal.config.websocket_allowed_origins = ["https://app.example.com"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      headers = ws_upgrade_headers_for_origin("https://evil.example")
+      headers["Connection"] = "keep-alive, Upgrade"
+      request = HTTP::Request.new("GET", "/", headers)
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
+    end
+
+    it "rejects malformed Origin with 403 instead of 500" do
+      Kemal.config.websocket_allowed_origins = ["https://app.example.com"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/" { }
+      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("http://a:b"))
+      assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
     end
 
     it "allows upgrade when Origin matches allowlist" do
@@ -126,6 +169,48 @@ describe "Kemal::WebSocketHandler" do
       request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("https://example.com:443"))
       io_with_context = create_ws_request_and_return_io_and_context(handler, request)[0]
       io_with_context.to_s.should contain("101 Switching Protocols")
+    end
+  end
+
+  describe "WebSocket connection smuggling" do
+    it "does not serve a pipelined HTTP request after a rejected upgrade" do
+      # PoC-shaped regression: compound Connection keeps the request classified as an
+      # upgrade (and fails Origin), but Connection: close on the 403 must stop the
+      # HTTP::Server keep-alive loop from reading the pipelined GET /secret.
+      Kemal.config.websocket_allowed_origins = ["https://app.example.com"]
+      Kemal.config.env = "test"
+      Kemal.config.logging = false
+
+      ws "/chat" { }
+      get "/secret" { "INTERNAL SECRET" }
+
+      Kemal.config.setup
+      server = HTTP::Server.new(Kemal.config.handlers)
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      payload = String.build do |b|
+        b << "GET /chat HTTP/1.1\r\n"
+        b << "Host: 127.0.0.1\r\n"
+        b << "Upgrade: websocket\r\n"
+        b << "Connection: keep-alive, Upgrade\r\n"
+        b << "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        b << "Sec-WebSocket-Version: 13\r\n"
+        b << "Origin: https://evil.example\r\n"
+        b << "\r\n"
+        b << "GET /secret HTTP/1.1\r\n"
+        b << "Host: 127.0.0.1\r\n"
+        b << "\r\n"
+      end
+
+      raw = raw_http_exchange("127.0.0.1", address.port, payload)
+      server.close
+
+      status_lines = raw.scan(/HTTP\/1\.1 \d{3}[^\r\n]*/).map(&.[0])
+      status_lines.size.should eq(1)
+      status_lines[0].should eq("HTTP/1.1 403 Forbidden")
+      raw.should match(/connection:\s*close/i)
+      raw.includes?("INTERNAL SECRET").should be_false
     end
   end
 end

--- a/src/kemal/websocket_handler.cr
+++ b/src/kemal/websocket_handler.cr
@@ -60,7 +60,7 @@ module Kemal
       return if o.empty?
       return "null" if o == "null"
 
-      uri = URI.parse(o)
+      uri = URI.parse(o) rescue return
       scheme_raw = uri.scheme
       host_raw = uri.host
       return unless scheme_raw && host_raw
@@ -80,6 +80,9 @@ module Kemal
 
     private def reject_websocket_forbidden!(context : HTTP::Server::Context)
       context.response.status_code = 403
+      # Close after rejection so a pipelined request cannot reuse this connection
+      # (WebSocket connection smuggling via `Connection: keep-alive, Upgrade`).
+      context.response.headers["Connection"] = "close"
       context.response.headers["Content-Type"] = "text/plain; charset=UTF-8"
       context.response.print "Forbidden"
     end


### PR DESCRIPTION
### Summary

When a WebSocket upgrade fails Origin validation, Kemal returned `403 Forbidden` but did **not** set `Connection: close`. Combined with a compound request header such as `Connection: keep-alive, Upgrade`:

1. Kemal treats the request as a WebSocket upgrade (`includes_word?("Connection", "Upgrade")`)
2. Origin check rejects it with 403
3. Crystal’s `HTTP.keep_alive?` does **not** match the exact token `"upgrade"`, so the connection stays keep-alive
4. A pipelined HTTP request on the same TCP connection is still processed

Behind a reverse proxy that tunnels on WebSocket upgrade *intent* (without waiting for `101`), that pipelined request can bypass the proxy’s path ACLs / auth — classic WebSocket connection smuggling (CWE-444 → CWE-863).

This was introduced with Origin validation in 1.12.0 (#749) on the rejection path. Successful `101` upgrades are unaffected (bytes go to the WebSocket stream).

**Fix**
- Set `Connection: close` in `reject_websocket_forbidden!` so the HTTP server loop closes after rejection and never reads the next pipelined request
- Rescue `URI::Error` in `normalize_websocket_origin` so a malformed `Origin` (e.g. `http://a:b`) returns 403 instead of an unauthenticated 500

**Tests**
- Unit: all Origin-rejection paths assert `403` + `Connection: close`
- Integration: live `HTTP::Server` with `Connection: keep-alive, Upgrade` + pipelined `GET /secret` — expects a single 403 and no secret body

### Alternate Designs

- Reject compound `Connection` tokens / require exact `Upgrade` only — would diverge from common clients that send `keep-alive, Upgrade` and from RFC 6455’s token list semantics
- Close the socket manually outside the response headers — more brittle than using Crystal’s existing keep-alive decision via `Connection: close`

Setting `Connection: close` on the 403 is the smallest change that matches how Crystal decides keep-alive.

### Benefits

- Stops HTTP request smuggling via rejected WebSocket upgrades when Kemal sits behind a tunneling reverse proxy
- Fail-closed handling for malformed `Origin` (403 instead of 500)
- Regression coverage at both handler and TCP/pipeline level

### Possible Drawbacks

- Clients that relied on keep-alive reuse *after* a rejected WebSocket upgrade will need a new connection (correct HTTP behavior; rare in practice)
- Does not change empty-allowlist / same-origin-by-default policy (tracked separately in the CSWSH work); this PR only hardens the rejection path that already returns 403 when an allowlist is configured