### PR TITLE
Add HTTP QUERY method (RFC 10008) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+- Add HTTP QUERY method support ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) [#762](https://github.com/kemalcr/kemal/issues/762): `query` route DSL, `Kemal::Router#query`, and `before_query` / `after_query` filters. A QUERY request that has a body but no `Content-Type` header is rejected with `400` per the RFC; media-type decisions (415/406/422) and the `Accept-Query` response header remain in the application's hands. Thanks @canermastan for the request :pray:
+
+```crystal
+query "/search" do |env|
+  q = env.params.json["q"]? # or env.params.body for form-encoded queries
+  search_products(q).to_json
+end
+```
+
 - ***(SECURITY)*** Escape the request path and the exception message on the development error page. Both reached the `exception_page` template unescaped, so a crafted URL — or user input interpolated into an exception message, e.g. `raise "User #{name} not found"` — could run JavaScript in the visitor's browser (reflected XSS). The page is now also served with a restrictive `Content-Security-Policy`. Only affects `Kemal.config.env == "development"`, which is the default; the production error page never reflected request data. Thanks @onurcangnc for the report :pray:
 
 - ***(SECURITY)*** WebSocket Origin validation is same-origin by default (CSWSH). An empty `websocket_allowed_origins` now requires `Origin` to match the request `Host` (scheme taken from `Origin`, so reverse-proxy TLS termination keeps working). Missing or empty `Origin` is rejected with 403. Set `Kemal.config.websocket_allowed_origins = ["*"]` to opt into allowing any origin, including requests without `Origin`. Explicit allowlists behave as before.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ Yes, built-in. No extra dependencies needed.
 
 Yes. JSON handling is built-in. Return hashes or JSON directly from routes.
 
+**Does Kemal support the HTTP QUERY method?**
+
+Yes. QUERY ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) is a safe, idempotent method that carries the query in the request body instead of the URL:
+
+```crystal
+query "/search" do |env|
+  q = env.params.json["q"]? # or env.params.body for form-encoded queries
+  search_products(q).to_json
+end
+```
+
+`before_query` / `after_query` filters and `Kemal::Router#query` work like every other verb. A QUERY request that has a body but no `Content-Type` header is rejected with `400` per the RFC.
+
 **Does Kemal work with any ORM?**
 
 Yes. You can use any Crystal ORM or database library. No forced dependencies.

--- a/spec/middleware/filters_spec.cr
+++ b/spec/middleware/filters_spec.cr
@@ -73,6 +73,39 @@ describe "Kemal::FilterHandler" do
     client_response.body.should eq("false")
   end
 
+  it "executes before_query filter for QUERY requests but not GET requests" do
+    before_query "/greetings" do |env|
+      env.set "filtered", "true"
+    end
+
+    query "/greetings" do |env|
+      env.get?("filtered").to_s
+    end
+
+    get "/greetings" do |env|
+      env.get?("filtered").to_s
+    end
+
+    query_response = call_request_on_app(HTTP::Request.new("QUERY", "/greetings"))
+    query_response.body.should eq("true")
+
+    get_response = call_request_on_app(HTTP::Request.new("GET", "/greetings"))
+    get_response.body.should eq("")
+  end
+
+  it "executes after_query filter for QUERY requests" do
+    after_query "/greetings" do |env|
+      env.response.headers["X-After-Query"] = "applied"
+    end
+
+    query "/greetings" do
+      "hello"
+    end
+
+    response = call_request_on_app(HTTP::Request.new("QUERY", "/greetings"))
+    response.headers["X-After-Query"].should eq("applied")
+  end
+
   it "executes code after home request" do
     test_filter = FilterTest.new
     test_filter.modified = "false"

--- a/spec/override_method_handler_spec.cr
+++ b/spec/override_method_handler_spec.cr
@@ -14,6 +14,19 @@ describe "Kemal::OverrideMethodHandler" do
     context.request.method.should eq "POST"
   end
 
+  it "does not override method with _method=QUERY for POST requests" do
+    request = HTTP::Request.new(
+      "POST",
+      "/",
+      body: "_method=QUERY",
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"}
+    )
+
+    context = create_request_and_return_io_and_context(Kemal::OverrideMethodHandler::INSTANCE, request)[1]
+
+    context.request.method.should eq "POST"
+  end
+
   it "overrides method with _method for POST requests" do
     request = HTTP::Request.new(
       "POST",

--- a/spec/param_parser_spec.cr
+++ b/spec/param_parser_spec.cr
@@ -59,6 +59,28 @@ describe "ParamParser" do
     url_params["spanish"].should eq "año"
   end
 
+  it "parses url-encoded body of a QUERY request" do
+    request = HTTP::Request.new(
+      "QUERY",
+      "/",
+      body: "q=kemal",
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"},
+    )
+    body_params = Kemal::ParamParser.new(request).body
+    body_params["q"].should eq "kemal"
+  end
+
+  it "parses JSON body of a QUERY request" do
+    request = HTTP::Request.new(
+      "QUERY",
+      "/",
+      body: %({"q": "kemal"}),
+      headers: HTTP::Headers{"Content-Type" => "application/json"},
+    )
+    json_params = Kemal::ParamParser.new(request).json
+    json_params["q"].should eq "kemal"
+  end
+
   it "parses request body" do
     Route.new "POST", "/" do |env|
       name = env.params.query["name"]

--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -113,6 +113,191 @@ describe "Kemal::RouteHandler" do
     client_response.body.should eq("Skills ruby,crystal")
   end
 
+  it "routes QUERY request with url-encoded body params" do
+    query "/search" do |env|
+      "Searching for #{env.params.body["q"]}"
+    end
+    request = HTTP::Request.new(
+      "QUERY",
+      "/search",
+      body: "q=kemal",
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"},
+    )
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("Searching for kemal")
+  end
+
+  it "routes QUERY request with JSON body" do
+    query "/search" do |env|
+      "Searching for #{env.params.json["q"]}"
+    end
+    request = HTTP::Request.new(
+      "QUERY",
+      "/search",
+      body: {"q": "kemal"}.to_json,
+      headers: HTTP::Headers{"Content-Type" => "application/json"},
+    )
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("Searching for kemal")
+  end
+
+  it "keeps query string and body params separate for QUERY requests" do
+    query "/search" do |env|
+      "page #{env.params.query["page"]} q #{env.params.body["q"]}"
+    end
+    request = HTTP::Request.new(
+      "QUERY",
+      "/search?page=2",
+      body: "q=kemal",
+      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"},
+    )
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("page 2 q kemal")
+  end
+
+  it "does not serve a QUERY request from a GET route" do
+    error 404 do
+      "not found"
+    end
+    get "/only_get" do
+      "get"
+    end
+    Kemal::RouteHandler::INSTANCE.lookup_route("QUERY", "/only_get").found?.should be_false
+    request = HTTP::Request.new("QUERY", "/only_get")
+    client_response = call_request_on_app(request)
+    client_response.status_code.should eq(404)
+  end
+
+  it "does not serve GET or HEAD requests from a QUERY route" do
+    error 404 do
+      "not found"
+    end
+    query "/only_query" do
+      "query"
+    end
+    Kemal::RouteHandler::INSTANCE.lookup_route("GET", "/only_query").found?.should be_false
+    Kemal::RouteHandler::INSTANCE.lookup_route("HEAD", "/only_query").found?.should be_false
+    call_request_on_app(HTTP::Request.new("GET", "/only_query")).status_code.should eq(404)
+    call_request_on_app(HTTP::Request.new("HEAD", "/only_query")).status_code.should eq(404)
+  end
+
+  context "QUERY Content-Type enforcement (RFC 10008)" do
+    it "rejects a QUERY request that has a body but no Content-Type with 400" do
+      query "/search" do
+        "should not run"
+      end
+      request = HTTP::Request.new("QUERY", "/search", body: "q=kemal")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(400)
+      client_response.body.should eq("QUERY request with a body requires a Content-Type header")
+    end
+
+    it "rejects a chunked QUERY request without Content-Type with 400" do
+      query "/search" do
+        "should not run"
+      end
+      request = HTTP::Request.new(
+        "QUERY",
+        "/search",
+        headers: HTTP::Headers{"Transfer-Encoding" => "chunked"},
+        body: IO::Memory.new("q=kemal"),
+      )
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(400)
+    end
+
+    it "rejects a chunked QUERY request without Content-Type even when Content-Length is 0" do
+      query "/search" do
+        "should not run"
+      end
+      request = HTTP::Request.new(
+        "QUERY",
+        "/search",
+        headers: HTTP::Headers{"Content-Length" => "0", "Transfer-Encoding" => "chunked"},
+        body: IO::Memory.new("q=kemal"),
+      )
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(400)
+    end
+
+    it "rejects a QUERY request with duplicate Content-Length headers and no Content-Type" do
+      query "/search" do
+        "should not run"
+      end
+      headers = HTTP::Headers.new
+      headers.add("Content-Length", "7")
+      headers.add("Content-Length", "7")
+      request = HTTP::Request.new("QUERY", "/search", headers: headers, body: IO::Memory.new("q=kemal"))
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(400)
+    end
+
+    it "rejects a QUERY request with an empty Content-Type value" do
+      query "/search" do
+        "should not run"
+      end
+      request = HTTP::Request.new(
+        "QUERY",
+        "/search",
+        body: "q=kemal",
+        headers: HTTP::Headers{"Content-Type" => ""},
+      )
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(400)
+    end
+
+    it "lets a before_query filter halt before Content-Type validation" do
+      before_query "/search" do |env|
+        halt env, status_code: 401, response: "unauthorized"
+      end
+      query "/search" do
+        "should not run"
+      end
+      request = HTTP::Request.new("QUERY", "/search", body: "q=kemal")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(401)
+      client_response.body.should eq("unauthorized")
+    end
+
+    it "renders a custom error 400 handler for invalid QUERY requests" do
+      error 400 do
+        "custom bad request"
+      end
+      query "/search" do
+        "should not run"
+      end
+      request = HTTP::Request.new("QUERY", "/search", body: "q=kemal")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(400)
+      client_response.body.should eq("custom bad request")
+    end
+
+    it "allows a QUERY request without a body and without Content-Type" do
+      query "/search" do
+        "empty query"
+      end
+      request = HTTP::Request.new("QUERY", "/search")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.body.should eq("empty query")
+    end
+
+    it "allows a QUERY request with a body and a Content-Type" do
+      query "/search" do |env|
+        "q is #{env.params.body["q"]}"
+      end
+      request = HTTP::Request.new(
+        "QUERY",
+        "/search",
+        body: "q=kemal",
+        headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"},
+      )
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.body.should eq("q is kemal")
+    end
+  end
+
   it "can process HTTP HEAD requests for defined GET routes" do
     get "/" do
       "Hello World from GET"
@@ -259,6 +444,25 @@ describe "Kemal::RouteHandler" do
       # Second HEAD lookup should be a cache hit; size must remain 1
       Kemal::RouteHandler::INSTANCE.lookup_route("HEAD", "/head_fallback").found?.should be_true
       Kemal::RouteHandler::INSTANCE.cached_routes.size.should eq 1
+    end
+
+    it "caches QUERY and GET routes on the same path separately" do
+      Kemal::RouteHandler::INSTANCE.cached_routes = Kemal::LRUCache(String, Radix::Result(Kemal::Route)).new(16)
+
+      get "/dual" do
+        "get"
+      end
+      query "/dual" do
+        "query"
+      end
+
+      Kemal::RouteHandler::INSTANCE.lookup_route("GET", "/dual").found?.should be_true
+      Kemal::RouteHandler::INSTANCE.lookup_route("QUERY", "/dual").found?.should be_true
+      Kemal::RouteHandler::INSTANCE.cached_routes.size.should eq 2
+
+      # Cached lookups must keep resolving to their own method's handler
+      Kemal::RouteHandler::INSTANCE.lookup_route("GET", "/dual").payload.method.should eq "GET"
+      Kemal::RouteHandler::INSTANCE.lookup_route("QUERY", "/dual").payload.method.should eq "QUERY"
     end
 
     it "keeps size capped under heavy churn with large capacity" do

--- a/spec/route_spec.cr
+++ b/spec/route_spec.cr
@@ -21,5 +21,22 @@ describe "Route" do
         end
       end
     end
+
+    it "matches a QUERY route" do
+      query "/search" do
+        "QUERY search"
+      end
+      request = HTTP::Request.new("QUERY", "/search")
+      client_response = call_request_on_app(request)
+      client_response.body.should eq("QUERY search")
+    end
+
+    it "doesn't allow a QUERY route declaration start without /" do
+      expect_raises Kemal::Exceptions::InvalidPathStartException, "Route declaration query \"route\" needs to start with '/', should be query \"/route\"" do
+        query "route" do
+          "Route 1"
+        end
+      end
+    end
   end
 end

--- a/spec/router_spec.cr
+++ b/spec/router_spec.cr
@@ -81,6 +81,24 @@ describe "Kemal::Router" do
       client_response.headers["Allow"].should eq("GET, POST, OPTIONS")
     end
 
+    it "routes QUERY request with prefix" do
+      router = Kemal::Router.new
+      router.query "/users/search" do |env|
+        "searching for #{env.params.body["q"]}"
+      end
+
+      mount "/api", router
+
+      request = HTTP::Request.new(
+        "QUERY",
+        "/api/users/search",
+        body: "q=kemal",
+        headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"},
+      )
+      client_response = call_request_on_app(request)
+      client_response.body.should eq("searching for kemal")
+    end
+
     it "mounts router without prefix" do
       router = Kemal::Router.new
       router.get "/status" do
@@ -177,6 +195,32 @@ describe "Kemal::Router" do
       post_request = HTTP::Request.new("POST", "/api/test")
       post_response = call_request_on_app(post_request)
       post_response.body.should eq("post")
+    end
+
+    it "applies QUERY-specific before filter" do
+      router = Kemal::Router.new
+
+      router.before_query do |env|
+        env.set "method", "query"
+      end
+
+      router.query "/test" do |env|
+        env.get("method").to_s
+      end
+
+      router.get "/test" do |env|
+        env.get?("method").to_s
+      end
+
+      mount "/api", router
+
+      query_request = HTTP::Request.new("QUERY", "/api/test")
+      query_response = call_request_on_app(query_request)
+      query_response.body.should eq("query")
+
+      get_request = HTTP::Request.new("GET", "/api/test")
+      get_response = call_request_on_app(get_request)
+      get_response.body.should eq("")
     end
 
     it "applies filter to specific path" do

--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -103,7 +103,7 @@ describe Kemal::StaticFileHandler do
       response.status_code.should eq(200)
     end
 
-    %w[POST PUT DELETE].each do |method|
+    %w[POST PUT DELETE QUERY].each do |method|
       response = handle HTTP::Request.new(method, "/dir/test.txt")
       response.status_code.should eq(404)
       response = handle HTTP::Request.new(method, "/dir/test.txt"), false

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -3,14 +3,14 @@
 #
 # ## Available DSL Methods
 #
-# - **HTTP Routes**: `get`, `post`, `put`, `patch`, `delete`, `options`
+# - **HTTP Routes**: `get`, `post`, `put`, `patch`, `delete`, `options`, `query`
 # - **WebSocket**: `ws`
 # - **Server-Sent Events**: `sse`
 # - **Filters**: `before_all`, `before_get`, `after_all`, `after_get`, etc.
 # - **Error Handling**: `error`
 # - **Modular Routing**: `mount`
-HTTP_METHODS   = %w[get post put patch delete options]
-FILTER_METHODS = %w[get post put patch delete options all]
+HTTP_METHODS   = %w[get post put patch delete options query]
+FILTER_METHODS = %w[get post put patch delete options query all]
 
 # Defines a route for the given HTTP method.
 #
@@ -23,6 +23,21 @@ FILTER_METHODS = %w[get post put patch delete options all]
 #
 # post "/users" do |env|
 #   "User created"
+# end
+# ```
+#
+# `query` implements the HTTP QUERY method (RFC 10008): a safe, idempotent
+# request that carries the query in the request body, so handlers must not
+# change server state. A QUERY request that has a body but no `Content-Type`
+# header is rejected with 400. Responding with 415/406/422 for unsupported or
+# unprocessable query formats is up to the handler, which can advertise the
+# supported formats via the `Accept-Query` response header. Browsers always
+# send a CORS preflight for QUERY as it is not a CORS-safelisted method.
+#
+# ```
+# query "/search" do |env|
+#   q = env.params.json["q"]? # or env.params.body for form-encoded queries
+#   search_products(q).to_json
 # end
 # ```
 {% for method in HTTP_METHODS %}
@@ -103,8 +118,8 @@ end
 # Defines filters that run before or after requests.
 #
 # Available methods:
-# - `before_all`, `before_get`, `before_post`, `before_put`, `before_patch`, `before_delete`, `before_options`
-# - `after_all`, `after_get`, `after_post`, `after_put`, `after_patch`, `after_delete`, `after_options`
+# - `before_all`, `before_get`, `before_post`, `before_put`, `before_patch`, `before_delete`, `before_options`, `before_query`
+# - `after_all`, `after_get`, `after_post`, `after_put`, `after_patch`, `after_delete`, `after_options`, `after_query`
 #
 # ```
 # before_all do |env|

--- a/src/kemal/exception_handler.cr
+++ b/src/kemal/exception_handler.cr
@@ -14,7 +14,13 @@ module Kemal
       if Kemal.config.error_handlers.has_key?(413)
         call_exception_with_status_code(context, ex, 413)
       else
-        call_payload_too_large(context, ex)
+        call_default_exception(context, ex, 413)
+      end
+    rescue ex : Kemal::Exceptions::InvalidQueryRequest
+      if Kemal.config.error_handlers.has_key?(400)
+        call_exception_with_status_code(context, ex, 400)
+      else
+        call_default_exception(context, ex, 400)
       end
     rescue ex : Exception
       # Matches an error handler for the given exception
@@ -62,11 +68,13 @@ module Kemal
       end
     end
 
-    private def call_payload_too_large(context : HTTP::Server::Context, exception : Kemal::Exceptions::PayloadTooLarge)
+    # Renders a plain-text response for exceptions with a fixed status code
+    # when no custom error handler is registered for that code.
+    private def call_default_exception(context : HTTP::Server::Context, exception : Exception, status_code : Int32)
       return if context.response.closed? || context.response.headers_sent?
 
       context.response.content_type = "text/plain" unless context.response.headers.has_key?("Content-Type")
-      context.response.status_code = 413
+      context.response.status_code = status_code
       context.response.print exception.message if exception.message
       context
     end

--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -66,6 +66,11 @@ module Kemal
     # else goes into the radix tree with an @exact_filters hash cache for
     # O(1) lookup when adding multiple filters to the same path.
     def _add_route_filter(verb : String, path, type, &block : HTTP::Server::Context -> _)
+      # Ensure this handler is registered with Kemal (may have been cleared between tests)
+      unless Kemal::Config::FILTER_HANDLERS.includes?(self)
+        Kemal.config.add_filter_handler(self)
+      end
+
       if WILDCARD_PATHS.includes?(path)
         key = global_key(verb, type)
 

--- a/src/kemal/helpers/exceptions.cr
+++ b/src/kemal/helpers/exceptions.cr
@@ -24,4 +24,11 @@ module Kemal::Exceptions
       super "Payload Too Large"
     end
   end
+
+  # RFC 10008 requires QUERY request content to carry a media type.
+  class InvalidQueryRequest < Exception
+    def initialize
+      super "QUERY request with a body requires a Content-Type header"
+    end
+  end
 end

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -161,6 +161,7 @@ module Kemal
     private def process_request(context)
       raise Kemal::Exceptions::RouteNotFound.new(context) unless context.route_found?
       return if context.response.closed?
+      validate_query_request!(context.request)
       content = context.route.handler.call(context)
 
       if !Kemal.config.error_handlers.empty? && Kemal.config.error_handlers.has_key?(context.response.status_code)
@@ -172,6 +173,27 @@ module Kemal
       context
     ensure
       context.params.cleanup_temporary_files
+    end
+
+    # RFC 10008 requires failing a QUERY request whose content lacks a media
+    # type. Only the missing-header case is enforced here; rejecting
+    # unsupported or unprocessable media types (415/406/422) is up to the
+    # application.
+    private def validate_query_request!(request : HTTP::Request)
+      return unless request.method == "QUERY"
+      return if request.headers["Content-Type"]?.presence
+      raise Kemal::Exceptions::InvalidQueryRequest.new if request_has_body?(request)
+    end
+
+    # Body presence follows RFC 9112 message framing: Transfer-Encoding takes
+    # precedence over Content-Length, and an unparsable Content-Length falls
+    # back to how the request was actually framed.
+    private def request_has_body?(request : HTTP::Request) : Bool
+      return true if request.headers["Transfer-Encoding"]?.try(&.downcase.includes?("chunked"))
+      if length = request.headers["Content-Length"]?.try(&.to_i64?)
+        return length > 0
+      end
+      !request.body.nil?
     end
 
     private def radix_path(method, path)

--- a/src/kemal/router.cr
+++ b/src/kemal/router.cr
@@ -267,11 +267,6 @@ module Kemal
     private def register_filters(full_prefix : String, route_paths : Array(Tuple(String, String)))
       return if @filters.empty?
 
-      # Ensure FilterHandler is registered with Kemal (may have been cleared between tests)
-      unless Kemal::Config::FILTER_HANDLERS.includes?(Kemal::FilterHandler::INSTANCE)
-        Kemal.config.add_filter_handler(Kemal::FilterHandler::INSTANCE)
-      end
-
       @filters.each do |filter|
         # Determine which paths this filter applies to
         applicable_paths = if filter.path == "*"


### PR DESCRIPTION
Adds HTTP QUERY method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) support. Closes #762.

```crystal
query "/search" do |env|
  q = env.params.json["q"]? # or env.params.body for form-encoded queries
  search_products(q).to_json
end
```

- `query` route DSL, `Kemal::Router#query`, `before_query` / `after_query` filters — generated via the existing `HTTP_METHODS` / `FILTER_METHODS` macros, dispatch code unchanged.
- Bodies parse like any other method: form-encoded → `env.params.body`, JSON → `env.params.json`; URL query params stay separate in `env.params.query`.
- `OverrideMethodHandler` deliberately does **not** allow `_method=QUERY` (safe-method contract, CSRF surface).
- `FilterHandler` now re-registers itself with the config on filter registration (moved from the Router-only workaround), so top-level `before_*` / `after_*` DSL keeps working after `Kemal.config.clear` in test suites.

## RFC 10008 compliance

- [x] §2 — QUERY routes dispatch as a first-class safe/idempotent method; no implicit fallback to or from GET/HEAD
- [x] §2 — Request with content but missing (or empty) `Content-Type` fails with `400` before the handler runs; custom `error 400` handlers are honored. Body presence follows RFC 9112 framing (`Transfer-Encoding: chunked` takes precedence over `Content-Length`; unparsable `Content-Length` falls back to actual framing)
- [x] §2.1 — No content sniffing: body parsing is driven purely by the declared `Content-Type`
- [x] §2 — URI query component and query content coexist (`env.params.query` vs `env.params.body`/`env.params.json`); interpretation is left to the resource
- [x] §2.1 — `415` / `406` / `422` for unsupported, unacceptable or unprocessable query formats: resource-specific, left to the application (documented in the `query` docs)
- [x] §3 — `Accept-Query` advertisement: value only the application can know, documented instead of auto-generated
- [x] §§2.2–2.8 — `Location` / `Content-Location`, conditional requests, caching, redirects, range requests: client/cache/application concerns; nothing in the router interferes
- [x] §4 — Security: QUERY is not CORS-safelisted (always preflighted, documented); no body logging; request body limits (`max_request_body_size` → 413) apply as usual

Known limitation: `before_query` / `before_all` filters run before the 400 validation (handler-chain order), so filters can observe a not-yet-validated request. A filter that halts the response wins over the validation.
