### PR TITLE
Respond 400 instead of 500 for malformed request bodies

### DIFF
--- a/spec/exception_handler_spec.cr
+++ b/spec/exception_handler_spec.cr
@@ -272,6 +272,79 @@ describe "Kemal::ExceptionHandler" do
     response.body.should eq "Payload Too Large"
   end
 
+  it "renders 400 for a malformed JSON body" do
+    post "/j" do |env|
+      env.params.json["x"]?
+      "ok"
+    end
+
+    headers = HTTP::Headers{"Content-Type" => "application/json"}
+    request = HTTP::Request.new("POST", "/j", headers, body: "{ not valid json")
+    response = call_request_on_app(request)
+    response.status_code.should eq 400
+    response.body.should eq "Bad Request"
+  end
+
+  it "renders 400 for a malformed multipart body" do
+    post "/m" do |env|
+      env.params.files
+      "ok"
+    end
+
+    headers = HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=AaB03x"}
+    request = HTTP::Request.new("POST", "/m", headers, body: "not a real multipart payload")
+    response = call_request_on_app(request)
+    response.status_code.should eq 400
+  end
+
+  it "renders 400 for a multipart body without a boundary" do
+    post "/m2" do |env|
+      env.params.files
+      "ok"
+    end
+
+    headers = HTTP::Headers{"Content-Type" => "multipart/form-data"}
+    request = HTTP::Request.new("POST", "/m2", headers, body: "whatever")
+    response = call_request_on_app(request)
+    response.status_code.should eq 400
+  end
+
+  it "uses a custom 400 handler for malformed bodies" do
+    error 400 do
+      "custom bad request"
+    end
+    post "/j" do |env|
+      env.params.json["x"]?
+      "ok"
+    end
+
+    headers = HTTP::Headers{"Content-Type" => "application/json"}
+    request = HTTP::Request.new("POST", "/j", headers, body: "{ nope")
+    response = call_request_on_app(request)
+    response.status_code.should eq 400
+    response.body.should eq "custom bad request"
+  end
+
+  it "does not reclassify a parse error raised inside handler code as 400" do
+    # A JSON::ParseException from handler code (e.g. parsing an upstream API
+    # response) is a server error and must stay a 500, not be turned into a 400.
+    get "/" do
+      JSON.parse("{ not json")
+      "ok"
+    end
+
+    request = HTTP::Request.new("GET", "/")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    Kemal::ExceptionHandler::INSTANCE.next = Kemal::RouteHandler::INSTANCE
+    Kemal::ExceptionHandler::INSTANCE.call(context)
+    response.close
+    io.rewind
+    response = HTTP::Client::Response.from_io(io, decompress: false)
+    response.status_code.should eq 500
+  end
+
   it "escapes the exception message on the development error page" do
     get "/user-lookup" do |env|
       raise "User '#{env.params.query["name"]}' not found"

--- a/src/kemal/exception_handler.cr
+++ b/src/kemal/exception_handler.cr
@@ -11,17 +11,14 @@ module Kemal
     rescue ex : Kemal::Exceptions::CustomException
       call_exception_with_status_code(context, ex, context.response.status_code)
     rescue ex : Kemal::Exceptions::PayloadTooLarge
-      if Kemal.config.error_handlers.has_key?(413)
-        call_exception_with_status_code(context, ex, 413)
-      else
-        call_default_exception(context, ex, 413)
-      end
+      call_fixed_status(context, ex, 413)
     rescue ex : Kemal::Exceptions::InvalidQueryRequest
-      if Kemal.config.error_handlers.has_key?(400)
-        call_exception_with_status_code(context, ex, 400)
-      else
-        call_default_exception(context, ex, 400)
-      end
+      call_fixed_status(context, ex, 400)
+    rescue ex : Kemal::Exceptions::BadRequest
+      # A request body the framework could not parse (broken JSON, unparseable
+      # multipart) is a client error, so respond 400 instead of 500. Only body
+      # parsing raises this; a parse error in handler code keeps its 500.
+      call_fixed_status(context, ex, 400)
     rescue ex : Exception
       # Matches an error handler for the given exception
       #
@@ -65,6 +62,17 @@ module Kemal
         context.response.status_code = status_code
         context.response.print Kemal.config.error_handlers[status_code].call(context, exception)
         context
+      end
+    end
+
+    # Dispatches a framework-raised exception with a fixed status code: a custom
+    # handler registered for that status if present, otherwise a default
+    # plain-text response.
+    private def call_fixed_status(context : HTTP::Server::Context, exception : Exception, status_code : Int32)
+      if Kemal.config.error_handlers.has_key?(status_code)
+        call_exception_with_status_code(context, exception, status_code)
+      else
+        call_default_exception(context, exception, status_code)
       end
     end
 

--- a/src/kemal/helpers/exceptions.cr
+++ b/src/kemal/helpers/exceptions.cr
@@ -31,4 +31,14 @@ module Kemal::Exceptions
       super "QUERY request with a body requires a Content-Type header"
     end
   end
+
+  # Raised by `ParamParser` when the framework cannot parse the request body
+  # (broken JSON, unparseable multipart). Rendered as 400. Only wraps failures
+  # from Kemal's own body parsing, so a parse error inside handler code keeps
+  # its original class and 500 status.
+  class BadRequest < Exception
+    def initialize(message : String? = nil, cause : Exception? = nil)
+      super(message || "Bad Request", cause)
+    end
+  end
 end

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -184,6 +184,8 @@ module Kemal
       end
 
       @files_parsed = true
+    rescue ex : HTTP::FormData::Error | MIME::Multipart::Error
+      raise Kemal::Exceptions::BadRequest.new(cause: ex)
     end
 
     # Parses JSON request body if Content-Type is `application/json`.
@@ -206,6 +208,8 @@ module Kemal
       else
         # Ignore non Array or Hash json values
       end
+    rescue ex : JSON::ParseException
+      raise Kemal::Exceptions::BadRequest.new(cause: ex)
     end
 
     private def parse_part(part : IO?)


### PR DESCRIPTION
Hi @sdogruyol,

I noticed that when Kemal fails to parse a request body, it currently returns 500. I think 400 is the more correct status here. Every framework that parses request bodies for you (Rails, Flask, FastAPI, Express) treats a body it can't parse as a client error (4xx). Kemal also exposes parsing through env.params.json / env.params.files, so it fits that group. Sinatra returns 500, but it doesn't parse bodies for you. There it's app code, not the framework.

This does change behavior for anyone catching these errors, so I'd appreciate a review. If you'd rather keep 500, feel free to close the PR :)

### Description of the Change

A malformed request body (broken JSON or an unparseable multipart payload) currently hits the generic exception handler and comes back as 500. These are client errors, so this maps them to 400 Bad Request.

`ParamParser` now wraps parse failures from Kemal's own body parsing in `Kemal::Exceptions::BadRequest` (original exception kept as `cause`), and `ExceptionHandler` renders it as 400.

Added specs covering malformed JSON, malformed multipart, missing boundary, the `error 400` override, and that a parse error from handler code still returns 500.

Before this change:

```crystal
post "/j" do |env|
  env.params.json["x"]? # body: "{ not json"
  "ok"
end
# => 500 (should be 400)

post "/m" do |env|
  env.params.files # unparseable multipart / missing boundary
  "ok"
end
# => 500 (should be 400)
```

Scope notes:
- Parse errors raised inside handler code (e.g. `JSON.parse(upstream_response)`) keep their original class and stay 500. Only Kemal's own body parsing is remapped.
- Still customizable with `error 400 do ... end`.
- `PayloadTooLarge` (413) is untouched.

### Alternate Designs

**Keep 500.**
The main alternative. It felt wrong because a body the framework itself can't parse is a client error, not a server error. And every framework that does its own body parsing already returns 4xx.

**Map the raw `JSON::ParseException` / multipart errors to 400 directly, without wrapping.**  
Simpler, but it would also catch parse errors raised inside handler code (e.g. `JSON.parse(upstream_response)`) and mislabel a genuine server error as 400 while dropping it from the logs. Wrapping only Kemal's own body parsing in `BadRequest` keeps that boundary clean.

**Make it opt-in via config.**  
Rejected. It leaves the incorrect default in place and adds a knob almost nobody would touch.

### Benefits

Correct HTTP semantics, better alignment with Rails/Flask/FastAPI and friends, and a clearer split between framework-level parsing failures and actual application errors. People already using `error 400` can catch these cleanly.

### Possible Drawbacks

Default status for malformed bodies goes from 500 to 400. Anyone currently catching these via `error 500` or `error JSON::ParseException` will need to move to `error 400`. It's a small behavior change, so worth deciding whether the semantic fix is worth the minor migration.