### PR TITLE
Reject non-GET WebSocket upgrade requests with 405 (RFC 6455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Kemal.config.websocket_allowed_origins = ["*"]
 
 - ***(SECURITY)*** Close the HTTP connection after a rejected WebSocket upgrade (403). Without `Connection: close`, a compound `Connection: keep-alive, Upgrade` request that fails Origin validation left the connection keep-alive, so a request pipelined behind a reverse proxy that tunnels upgrades could bypass the proxy’s access controls (WebSocket connection smuggling). Malformed `Origin` values that previously raised from `URI.parse` now reject with 403 instead of 500.
 
+- WebSocket upgrades now require the `GET` method per [RFC 6455 §4.1](https://www.rfc-editor.org/rfc/rfc6455.html#section-4.1) [#770](https://github.com/kemalcr/kemal/issues/770). Any other method (`POST`, `QUERY`, ...) carrying valid upgrade headers previously completed the handshake; it is now rejected with `405 Method Not Allowed`, an `Allow: GET` header, and `Connection: close` — matching the broader ecosystem (gorilla/websocket, Node `ws`, python-websockets).
+
 # 1.12.0 (21-07-2026)
 
 - Crystal 1.21.0 support :tada:

--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -352,5 +352,46 @@ describe "Kemal::WebSocketHandler" do
       raw.should match(/connection:\s*close/i)
       raw.includes?("INTERNAL SECRET").should be_false
     end
+
+    it "does not serve a pipelined HTTP request after a 405 method rejection" do
+      # Same PoC shape as the 403 spec above, but through the non-GET rejection
+      # path: even with an allowed (same-origin) Origin, a POST upgrade must get
+      # a single 405 and Connection: close must stop the keep-alive loop from
+      # reading the pipelined GET /secret.
+      Kemal.config.env = "test"
+      Kemal.config.logging = false
+
+      ws "/chat" { }
+      get "/secret" { "INTERNAL SECRET" }
+
+      Kemal.config.setup
+      server = HTTP::Server.new(Kemal.config.handlers)
+      address = server.bind_tcp("127.0.0.1", 0)
+      spawn { server.listen }
+
+      payload = String.build do |b|
+        b << "POST /chat HTTP/1.1\r\n"
+        b << "Host: 127.0.0.1\r\n"
+        b << "Upgrade: websocket\r\n"
+        b << "Connection: keep-alive, Upgrade\r\n"
+        b << "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        b << "Sec-WebSocket-Version: 13\r\n"
+        b << "Origin: http://127.0.0.1\r\n"
+        b << "\r\n"
+        b << "GET /secret HTTP/1.1\r\n"
+        b << "Host: 127.0.0.1\r\n"
+        b << "\r\n"
+      end
+
+      raw = raw_http_exchange("127.0.0.1", address.port, payload)
+      server.close
+
+      status_lines = raw.scan(/HTTP\/1\.1 \d{3}[^\r\n]*/).map(&.[0])
+      status_lines.size.should eq(1)
+      status_lines[0].should eq("HTTP/1.1 405 Method Not Allowed")
+      raw.should match(/allow:\s*GET/i)
+      raw.should match(/connection:\s*close/i)
+      raw.includes?("INTERNAL SECRET").should be_false
+    end
   end
 end

--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -28,6 +28,14 @@ def assert_websocket_forbidden_closed(response : HTTP::Client::Response)
   response.headers["Connection"]?.try(&.downcase).should eq("close")
 end
 
+def assert_websocket_method_not_allowed(response : HTTP::Client::Response)
+  response.status_code.should eq(405)
+  response.headers["Allow"]?.should eq("GET")
+  response.headers["Connection"]?.try(&.downcase).should eq("close")
+  response.headers["Content-Type"]?.should eq("text/plain; charset=UTF-8")
+  response.body.should eq("Method Not Allowed")
+end
+
 # Raw TCP exchange against a live HTTP::Server (needed to exercise Crystal keep-alive).
 def raw_http_exchange(host : String, port : Int32, payload : String, read_seconds = 1) : String
   socket = nil.as(TCPSocket?)
@@ -107,6 +115,37 @@ describe "Kemal::WebSocketHandler" do
     request = HTTP::Request.new("GET", "/")
     client_response = call_ws_handler_response(handler, request)
     client_response.body.should eq("get")
+  end
+
+  describe "handshake method (RFC 6455)" do
+    %w[POST QUERY HEAD].each do |method|
+      it "rejects a #{method} upgrade request with 405 Method Not Allowed" do
+        handler = Kemal::WebSocketHandler::INSTANCE
+        ws "/chat" { }
+        headers = ws_upgrade_headers_for_origin("http://localhost")
+        headers["Host"] = "localhost"
+        request = HTTP::Request.new(method, "/chat", headers)
+        assert_websocket_method_not_allowed(call_ws_handler_response(handler, request))
+      end
+    end
+
+    it "rejects a non-GET upgrade with 405 before the Origin check" do
+      Kemal.config.websocket_allowed_origins = ["https://app.example.com"]
+      handler = Kemal::WebSocketHandler::INSTANCE
+      ws "/chat" { }
+      request = HTTP::Request.new("POST", "/chat", ws_upgrade_headers_for_origin("https://evil.example"))
+      assert_websocket_method_not_allowed(call_ws_handler_response(handler, request))
+    end
+
+    it "passes a non-GET request without upgrade headers to the next handler" do
+      handler = Kemal::WebSocketHandler::INSTANCE
+      handler.next = Kemal::RouteHandler::INSTANCE
+      ws "/" { }
+      post "/" { "post" }
+      request = HTTP::Request.new("POST", "/")
+      client_response = call_ws_handler_response(handler, request)
+      client_response.body.should eq("post")
+    end
   end
 
   describe "websocket_allowed_origins" do

--- a/src/kemal/websocket_handler.cr
+++ b/src/kemal/websocket_handler.cr
@@ -11,6 +11,10 @@ module Kemal
 
     def call(context : HTTP::Server::Context)
       return call_next(context) unless context.ws_route_found? && websocket_upgrade_request?(context)
+      unless context.request.method == "GET"
+        reject_websocket_method_not_allowed!(context)
+        return
+      end
       unless websocket_origin_allowed?(context.request)
         reject_websocket_forbidden!(context)
         return
@@ -103,12 +107,24 @@ module Kemal
     end
 
     private def reject_websocket_forbidden!(context : HTTP::Server::Context)
-      context.response.status_code = 403
+      reject_websocket!(context, :forbidden)
+    end
+
+    # RFC 6455 §4.1 requires the opening handshake to be a GET request.
+    private def reject_websocket_method_not_allowed!(context : HTTP::Server::Context)
+      context.response.headers["Allow"] = "GET"
+      reject_websocket!(context, :method_not_allowed)
+    end
+
+    private def reject_websocket!(context : HTTP::Server::Context, status : HTTP::Status)
+      # An upstream handler (e.g. a before filter) may have already responded.
+      return if context.response.closed?
+      context.response.status = status
       # Close after rejection so a pipelined request cannot reuse this connection
       # (WebSocket connection smuggling via `Connection: keep-alive, Upgrade`).
       context.response.headers["Connection"] = "close"
       context.response.headers["Content-Type"] = "text/plain; charset=UTF-8"
-      context.response.print "Forbidden"
+      context.response.print status.description
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

`Kemal::WebSocketHandler` previously gated the WebSocket upgrade solely on a matching ws route and the presence of `Upgrade` / `Connection` headers. The HTTP method itself was never validated, so any method (`POST`, `QUERY`, …) carrying valid upgrade headers could complete the handshake. RFC 6455 §4.1 requires the opening handshake to be a **GET** request.

This PR adds a method guard in `WebSocketHandler#call`, placed after the existing “is this an upgrade request for a ws route?” check and **before** the Origin check:

- Non-GET upgrade requests are rejected with `405 Method Not Allowed`, an `Allow: GET` header (required for 405 by RFC 9110 §10.2.1), and `Connection: close` — the same connection-smuggling protection already used by the 403 Origin rejection (#767).
- Requests without upgrade headers are left untouched: they fall through to the next handler exactly as before, so an HTTP route that shares a path with a ws route continues to work.
- Both rejection paths (403 / 405) now share a single `reject_websocket!` helper driven by `HTTP::Status`. The helper also skips writing if an upstream handler (e.g. a before filter) has already closed the response.

Before / after, using the reproduction from #770:

```bash
curl -si -X QUERY localhost:3000/chat \
  -H 'Upgrade: websocket' -H 'Connection: Upgrade' \
  -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
  -H 'Sec-WebSocket-Version: 13' \
  -H 'Origin: http://localhost:3000'
# before: HTTP/1.1 101 Switching Protocols
# after:  HTTP/1.1 405 Method Not Allowed
#         Allow: GET
#         Connection: close
```

Specs cover the full 405 response shape (status, `Allow`, `Connection: close`, `Content-Type`, body) for `POST` / `QUERY` / `HEAD`, confirm that the method check runs before the Origin check, and verify the unchanged fall-through for non-upgrade requests. A CHANGELOG entry is included.

### Alternate Designs

- **Fall through to the next handler instead of rejecting.**  
  RFC 9110 §7.8 allows a server to ignore `Upgrade` and process the request normally. Rejected: before this change a non-GET upgrade request never reached `RouteHandler` anyway (it was upgraded or returned 403), so falling through would be a larger behavior change. An explicit 405 also matches the wider ecosystem — gorilla/websocket and Node `ws` return 405, python-websockets returns 405 + `Allow: GET`, and Cowboy only upgrades GET.

- **Route the rejection through custom `error 405` handlers.**  
  Rejected for consistency: the 403 Origin rejection deliberately writes the response directly so the security-relevant shape (`Connection: close`) cannot be altered; the 405 path follows the same rule.

- **Compute `Allow` dynamically from coexisting routes on the same path.**  
  Rejected as overkill: it would couple `WebSocketHandler` to `RouteHandler` internals. A static `Allow: GET` correctly describes the upgrade resource and matches python-websockets’ behavior.

### Benefits

- RFC 6455 §4.1 conformance and parity with the broader WebSocket ecosystem.
- A clear, diagnosable `405` + `Allow: GET` instead of a protocol-violating `101` that can confuse intermediaries (or a misleading `403` that suggests an Origin problem).
- A slightly more robust rejection path: shared helper, reason phrases taken from `HTTP::Status`, and no write attempt on an already-closed response.

### Possible Drawbacks

- **Behavior change.** Clients that (incorrectly) performed the handshake with a non-GET method previously received `101` (allowed origin) or `403`, and now receive `405`. This is documented in the CHANGELOG; such clients were already violating RFC 6455.
- A non-GET request that carries upgrade headers to a path shared by a ws route and an HTTP route is answered with `405` rather than reaching the HTTP route. This is **not a regression** — previously the request never reached the route either (it was upgraded or returned 403) — and requests without upgrade headers are unaffected.
- `Allow: GET` is static; it does not enumerate methods of HTTP routes that coexist on the same path (see Alternate Designs).