### PR TITLE
Add Crystal-Kemal agent skill

### DIFF
--- a/.github/skills/crystal-kemal/SKILL.md
+++ b/.github/skills/crystal-kemal/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: crystal-kemal
+description: Use when building, reviewing, debugging, testing, securing, or deploying web applications and HTTP APIs with the Kemal framework for Crystal. Covers Kemal routing, params, context, routers, filters, middleware, ECR, WebSockets, SSE, uploads, configuration, testing, and production concerns.
+license: MIT
+---
+
+# Kemal development
+
+Use this skill for Kemal-specific work. Assume normal Crystal language knowledge and follow the Crystal documentation for language semantics that are not specific to Kemal.
+
+## Core rules
+
+- Prefer Kemal's own APIs and terminology over Ruby/Sinatra assumptions.
+- Match parameters to the request encoding: `env.params.url`, `.query`, `.json`, `.body`, and `.files` are not interchangeable.
+- Route definition order matters: the first matching route wins.
+- Use `Kemal::Router` and namespaces to structure larger applications.
+- Use filters for concise route-lifecycle behavior; use middleware for reusable handler-layer concerns and plugins.
+- A middleware handler must call `call_next` only when processing should continue.
+- Keep business logic out of ECR templates.
+- Treat every request-derived value as untrusted until validated.
+- Do not pass unchecked user-controlled paths to `send_file`.
+- Configure production WebSocket origins explicitly when browser clients are expected; origin validation is not authentication.
+- Add or update specs when route or middleware behavior changes.
+- Prefer current Kemal repository APIs over patterns remembered from older versions.
+
+## Quick start
+
+```crystal
+require "kemal"
+
+get "/" do
+  "Hello World!"
+end
+
+Kemal.run
+```
+
+Add Kemal to `shard.yml`:
+
+```yaml
+dependencies:
+  kemal:
+    github: kemalcr/kemal
+```
+
+Then:
+
+```bash
+shards install
+crystal run src/my_app.cr
+```
+
+## Routing
+
+Kemal supports the common HTTP verbs plus `QUERY`:
+
+```crystal
+get "/users"
+post "/users"
+put "/users/:id"
+patch "/users/:id"
+delete "/users/:id"
+query "/search"
+```
+
+Routes are matched in definition order. Check broad/wildcard routes for shadowing before adding more specific routes later.
+
+Dynamic route parameters:
+
+```crystal
+get "/users/:id" do |env|
+  id = env.params.url["id"]
+  env.json({id: id})
+end
+```
+
+Wildcard remainder:
+
+```crystal
+get "/files/*all" do |env|
+  env.params.url["all"]
+end
+```
+
+For `QUERY`, use the same Kemal parameter APIs appropriate to the request body. A QUERY request with a body and no `Content-Type` is rejected according to Kemal's current behavior.
+
+## Parameters
+
+Query parameters:
+
+```crystal
+width = env.params.query["width"]
+```
+
+JSON body (`Content-Type: application/json`):
+
+```crystal
+name = env.params.json["name"].as(String)
+```
+
+Form/body parameters:
+
+```crystal
+name = env.params.body["name"].as(String)
+```
+
+Repeated/bracketed form keys must be accessed exactly as sent, for example `env.params.body["likes[]"]`.
+
+Uploads are available through `env.params.files`.
+
+## Request and response context
+
+Prefer response helpers when they express the result clearly:
+
+```crystal
+get "/users" do |env|
+  env.json({users: ["alice", "bob"]})
+end
+
+post "/users" do |env|
+  env.status(:created).json({created: true})
+end
+```
+
+Manual response control remains available through `env.response` for headers, status, and content type.
+
+Use `halt` inside routes when route execution must stop:
+
+```crystal
+get "/admin" do |env|
+  halt env.status(403).html("<h1>Forbidden</h1>")
+end
+```
+
+Do not treat `halt` as generic middleware control flow.
+
+## Modular routers
+
+```crystal
+api = Kemal::Router.new
+
+api.namespace "/users" do
+  get "/" do |env|
+    env.json({users: ["alice", "bob"]})
+  end
+end
+
+mount "/api/v1", api
+```
+
+Routers can contain routes, filters, WebSockets, SSE endpoints, and nested namespaces. Keep router-scoped behavior scoped unless global behavior is intentional.
+
+## Filters and middleware
+
+Common filters include `before_all`, verb-specific `before_*` and matching `after_*` filters, including `before_query` / `after_query` for QUERY routes.
+
+Typical order:
+
+```text
+before_all -> before_<verb> -> route -> after_<verb> -> after_all
+```
+
+Reusable cross-cutting behavior belongs in middleware:
+
+```crystal
+class CustomHandler < Kemal::Handler
+  def call(env)
+    # before
+    call_next env
+    # after, if appropriate
+  end
+end
+
+add_handler CustomHandler.new
+```
+
+Do not call `call_next` after intentionally short-circuiting the request.
+
+## Views
+
+Render ECR templates with `render` and use a second path for layouts. Layout content is available as `content`; `content_for` / `yield_content` can define named slots.
+
+Keep application and authorization logic outside templates.
+
+## Security-sensitive behavior
+
+- Validate dynamic `send_file` paths using canonical containment inside an allowed root.
+- Validate upload presence, size, type/extension as appropriate, and destination path before persistence.
+- Use server-controlled upload names when client filenames could affect paths.
+- Keep private uploads outside automatically served public directories.
+- Set explicit request/multipart size limits appropriate to the application.
+- Keep secrets outside source control.
+- Avoid leaking stack traces, filesystem paths, database errors, tokens, or session secrets.
+- Use HTTPS in production and configure security headers at a deliberate layer.
+- Treat WebSocket origin checks as an additional browser boundary, not authentication/authorization.
+
+## Testing
+
+Use `spec-kemal` for application-level Kemal specs:
+
+```yaml
+development_dependencies:
+  spec-kemal:
+    github: kemalcr/spec-kemal
+```
+
+```crystal
+require "spec-kemal"
+require "../src/my_app"
+
+describe "My App" do
+  it "renders /" do
+    get "/"
+    response.body.should eq "Hello World!"
+  end
+end
+```
+
+Run:
+
+```bash
+KEMAL_ENV=test crystal spec
+```
+
+Test success and rejection paths, status codes, content types, parameter decoding, route ordering, middleware behavior, authorization, and upload/path validation where relevant.
+
+## Load detailed references only when relevant
+
+For more detail, read the smallest relevant reference file instead of loading everything:
+
+- Routing, params, context, routers, views, filters, middleware, errors, static files: [`references/http-core.md`](references/http-core.md)
+- Sessions, uploads, WebSockets, SSE, caching: [`references/realtime-state.md`](references/realtime-state.md)
+- Limits, security, configuration, tests, builds, proxies, databases, checklist: [`references/operations.md`](references/operations.md)
+
+## Verification checklist
+
+Before considering Kemal work complete:
+
+- [ ] Route ordering does not shadow expected endpoints.
+- [ ] Each route uses the intended HTTP verb, including `QUERY` where applicable.
+- [ ] URL/query/JSON/form/file params use the correct `env.params.*` source.
+- [ ] Inputs are validated at trust boundaries.
+- [ ] Status codes and content types are intentional.
+- [ ] Router/filter/middleware scope is correct.
+- [ ] Middleware continues with `call_next` only when intended.
+- [ ] Dynamic file paths and uploads cannot escape allowed storage roots.
+- [ ] WebSocket origin policy is explicit when needed and auth is handled separately.
+- [ ] Request and multipart limits are intentional.
+- [ ] Relevant `spec-kemal` tests pass.
+- [ ] Production build and deployment behavior are verified for the target platform.
+
+## Sources
+
+Treat the current Kemal repository and official Kemal documentation as the source of truth. Use current APIs when this skill conflicts with newer project documentation.

--- a/.github/skills/crystal-kemal/references/http-core.md
+++ b/.github/skills/crystal-kemal/references/http-core.md
@@ -1,0 +1,66 @@
+# Kemal HTTP core reference
+
+## Method override
+
+HTML forms directly support GET and POST. When PUT/PATCH/DELETE-style forms are required, add `Kemal::OverrideMethodHandler::INSTANCE` explicitly and use the `_method` form parameter. Do not assume the handler is enabled by default.
+
+## Context storage
+
+Store request-scoped values with `env.set`; retrieve them with `env.get` or `env.get?`. Register custom types with `add_context_storage_type(Type)` before use. Context storage is request-local, not persistent process state.
+
+## ECR
+
+```crystal
+get "/:name" do |env|
+  name = env.params.url["name"]
+  render "src/views/hello.ecr"
+end
+```
+
+Layouts:
+
+```crystal
+render "src/views/page.ecr", "src/views/layouts/layout.ecr"
+```
+
+The layout renders the child result through `<%= content %>`. Use `content_for` and `yield_content` for named slots.
+
+## Filters
+
+Filters are route-lifecycle hooks. Multiple filters for the same verb/path run in definition order. Global wildcard filters can still affect router-scoped routes.
+
+Plugins and reusable addons should prefer middleware over injecting broad filters.
+
+## Middleware
+
+Global/path-scoped middleware can be registered with `use`; custom handlers inherit from `Kemal::Handler`.
+
+Be explicit about whether a handler is global, path-scoped, `only`, or `exclude` constrained. A short-circuiting handler must not continue into the remainder of the chain.
+
+## Custom logger
+
+Subclass `Kemal::BaseLogHandler` and assign `Kemal.config.logger`. Avoid logging credentials, tokens, sensitive headers, session secrets, or raw sensitive request bodies.
+
+## Redirects and errors
+
+Use `env.redirect` for route redirects. Clear authentication/session state first when logout semantics require it.
+
+Status handlers use `error 404 do ... end`; exception handlers use `error MyError do ... end`. Definition order affects exception-handler resolution, so check broad handlers before narrower ones.
+
+Production error responses must not expose stack traces, internal paths, secrets, or database details.
+
+## `send_file`
+
+For dynamic paths:
+
+1. Define an allowed root.
+2. Canonicalize/normalize the requested candidate.
+3. Verify the resolved path remains inside the allowed root.
+4. Reject traversal and unexpected absolute paths.
+5. Apply authorization independently of path containment.
+
+Literal substring checks such as only searching for `../` are not a complete containment boundary.
+
+## Static files
+
+Kemal serves files from its public directory automatically. Configure `Kemal.config.public_folder` and `Kemal.config.serve_static` as needed. Avoid redundant routes that shadow static-file behavior and keep directory listing disabled unless intentionally required.

--- a/.github/skills/crystal-kemal/references/operations.md
+++ b/.github/skills/crystal-kemal/references/operations.md
@@ -1,0 +1,72 @@
+# Kemal operations reference
+
+## Resource limits
+
+Set application-specific limits rather than copying example values blindly:
+
+```crystal
+Kemal.config.max_request_body_size = 10 * 1024 * 1024
+Kemal.config.max_multipart_form_field_size = 8 * 1024 * 1024
+```
+
+Multipart limits apply to individual multipart fields/file parts according to current Kemal behavior.
+
+## Security baseline
+
+Typical controls include explicit WebSocket origins, hidden framework headers when desired, request/upload limits, HTTPS, deliberate security headers, authorization on sensitive routes, server-controlled file paths, and protection of secrets.
+
+Third-party security middleware may be appropriate, but verify maintenance status and compatibility before adding dependencies.
+
+## Configuration
+
+Common settings include environment, port, host binding, shutdown timeout, public folder, static serving, SSL certificate/key paths, logger, and rescue behavior. Use deployment configuration or secret stores for environment-specific secrets.
+
+## Testing
+
+Use `spec-kemal` and run `KEMAL_ENV=test crystal spec`. Cover route verbs, params, status/content type, authn/authz, middleware, errors, upload rejection, and realtime behavior where practical.
+
+## Production builds
+
+Typical optimized build:
+
+```bash
+crystal build --release src/my_app.cr -o bin/app
+```
+
+Static linking is platform/toolchain dependent; verify the actual deployment target. Keep builder/runtime images aligned with the project's supported Crystal version instead of pinning stale example tags.
+
+## Reverse proxies
+
+For nginx or other proxies:
+
+- Preserve WebSocket upgrade headers.
+- Set suitable read timeouts for WebSockets/SSE.
+- Avoid unintended SSE buffering.
+- Terminate TLS consistently.
+- Decide deliberately whether static files and security headers are owned by the proxy or Kemal.
+
+## Databases
+
+Kemal does not replace database pool management. Follow the chosen database shard's API, keep credentials outside source, use bounded pools/timeouts, parameterized queries, and non-sensitive health responses.
+
+## Common pitfalls
+
+1. Reading JSON/query/form data from the wrong `env.params.*` collection.
+2. Dropping brackets from repeated form keys such as `likes[]`.
+3. Route shadowing due to definition order.
+4. Treating `halt` as generic middleware control flow.
+5. Forgetting `add_context_storage_type` for custom context types.
+6. Putting business logic into ECR.
+7. Using filters where reusable middleware is more appropriate.
+8. Calling `call_next` after a deliberate short circuit.
+9. Registering broad exception handlers before intended narrow handlers.
+10. Leaving WebSocket origins open unintentionally.
+11. Treating origin validation as authentication.
+12. Saving client filenames directly.
+13. Using only a `../` substring test as path-traversal defense.
+14. Serving private uploads from the public directory.
+15. Ignoring multipart field limits.
+16. Hard-coding session or deployment secrets.
+17. Using development-only session storage as durable production storage.
+18. Ignoring lifecycle/timeouts for long-lived streams.
+19. Copying stale deployment image/toolchain versions.

--- a/.github/skills/crystal-kemal/references/realtime-state.md
+++ b/.github/skills/crystal-kemal/references/realtime-state.md
@@ -1,0 +1,61 @@
+# Kemal state and realtime reference
+
+## File uploads
+
+Uploaded files are available through `env.params.files`; useful properties include `filename`, `tempfile`, `size`, and `headers`.
+
+Before saving:
+
+- Ensure the expected parameter exists.
+- Enforce size limits.
+- Allow-list expected types/extensions when appropriate.
+- Generate a server-controlled destination name.
+- Validate path containment.
+- Do not trust the client filename as a storage path.
+- Keep sensitive uploads outside public static roots.
+
+Tune `Kemal.config.max_multipart_form_field_size` to the intended upload profile.
+
+## Sessions
+
+Session support is provided by `kemal-session`, not core Crystal language semantics. Keep session secrets outside source control and select a storage engine suitable for the deployment topology. In-memory storage is suitable for development/testing but is not durable shared production storage.
+
+Follow the installed `kemal-session` version for CSRF/session APIs rather than inventing helper methods.
+
+## WebSockets
+
+```crystal
+ws "/" do |socket|
+  socket.on_message do |message|
+    socket.send "Echo: #{message}"
+  end
+end
+```
+
+With context:
+
+```crystal
+ws "/:id" do |socket, context|
+  id = context.ws_route_lookup.params["id"]
+end
+```
+
+Configure production browser origins with `Kemal.config.websocket_allowed_origins`. An empty list means checks are not enforced. Origin validation does not replace authentication or authorization.
+
+Handle disconnects and lifecycle/shutdown behavior for long-lived connections.
+
+## Server-Sent Events
+
+Use SSE for one-way server-to-client streaming:
+
+```crystal
+sse "/events" do |stream, env|
+  stream.send("tick", event: "tick", id: 1)
+end
+```
+
+Use WebSockets instead when full duplex is required. Avoid busy loops and account for proxy buffering, disconnects, and long-lived timeouts.
+
+## Caching
+
+When using `kemal-cache`, register its handler before the routes it should affect. Do not blindly cache authenticated, cookie-sensitive, or user-specific responses. Cache correctness and isolation take precedence over hit rate. Verify third-party shard compatibility with the project's supported versions.


### PR DESCRIPTION
## Summary

Adds a repository-level Agent Skill for Kemal development under:

```text
.github/skills/crystal-kemal/
```

The skill provides concise, task-oriented guidance for coding agents working with Kemal, including:

* routing and route parameters
* request and response handling
* `Kemal::Router` and namespaces
* filters and middleware
* ECR views
* WebSockets and Server-Sent Events
* sessions and file uploads
* security-related configuration
* testing with `spec-kemal`
* deployment and operational guidance

The main `SKILL.md` contains the core instructions, while more detailed framework guidance is split into reference files that agents can consult when relevant.

The content is based on Kemal's current documentation and repository APIs.

Closes #768
