### PR TITLE
Fix outdated WebSocket origin guidance in agent skill

### DIFF
--- a/.github/skills/crystal-kemal/references/realtime-state.md
+++ b/.github/skills/crystal-kemal/references/realtime-state.md
@@ -40,7 +40,30 @@ ws "/:id" do |socket, context|
 end
 ```
 
-Configure production browser origins with `Kemal.config.websocket_allowed_origins`. An empty list means checks are not enforced. Origin validation does not replace authentication or authorization.
+Configure browser WebSocket origin policy with
+`Kemal.config.websocket_allowed_origins`.
+
+By default, an empty `websocket_allowed_origins` list enforces same-origin
+WebSocket connections.
+
+Use an explicit allowlist when trusted cross-origin browser clients need
+access:
+
+```crystal
+Kemal.config.websocket_allowed_origins = [
+  "https://myapp.com",
+  "http://localhost:3000",
+]
+```
+
+To explicitly allow connections from any origin:
+
+```crystal
+Kemal.config.websocket_allowed_origins = ["*"]
+```
+
+Origin validation is an additional browser security boundary and does not
+replace application authentication or authorization.
 
 Handle disconnects and lifecycle/shutdown behavior for long-lived connections.
 


### PR DESCRIPTION
## Summary

- Updates `realtime-state.md` to reflect the current same-origin default introduced in 385b58c.
- An empty `websocket_allowed_origins` list now enforces same-origin (not "checks are not enforced").
- Documents explicit `["*"]` for allow-all behavior.

Addresses @hahwul's review comment on #774.

## Test plan

- [x] Verified against commit 385b58c and current `websocket_handler.cr` source.
- [x] Confirmed no other files in the agent skill contain the outdated statement.