### PR TITLE
Send Host in the WebSocket handshake specs

### DIFF
--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -1,12 +1,17 @@
 require "./spec_helper"
 require "socket"
 
+# `Host` is part of a well formed HTTP/1.1 request and Crystal's
+# `HTTP::WebSocketHandler` rejects an upgrade without it, so it belongs in the
+# baseline headers. Specs that care about a particular host - or about its
+# absence - override or delete it.
 def ws_upgrade_headers_for_origin(origin : String? = nil)
   h = HTTP::Headers{
     "Upgrade"               => "websocket",
     "Connection"            => "Upgrade",
     "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
     "Sec-WebSocket-Version" => "13",
+    "Host"                  => "localhost",
   }
   h["Origin"] = origin if origin
   h
@@ -269,7 +274,9 @@ describe "Kemal::WebSocketHandler" do
       Kemal.config.websocket_allowed_origins = [] of String
       handler = Kemal::WebSocketHandler::INSTANCE
       ws "/" { }
-      request = HTTP::Request.new("GET", "/", ws_upgrade_headers_for_origin("http://localhost"))
+      headers = ws_upgrade_headers_for_origin("http://localhost")
+      headers.delete("Host")
+      request = HTTP::Request.new("GET", "/", headers)
       assert_websocket_forbidden_closed(call_ws_handler_response(handler, request))
     end
 


### PR DESCRIPTION
The `nightly` CI jobs have been failing on all three OSes while every stable Crystal (1.16.3 – 1.19.2, `latest`) passes. Not a Kemal regression: it reproduces on unrelated branches, including #777, which touches no `src/` code.

## Cause

crystal-lang/crystal#17235 — *Validate method, version, and host in `HTTP::WebSocketHandler`* (merged 2026-08-19) — added:

```crystal
unless context.request.headers.has_key?("Host")
  response.respond_with_status(:bad_request)
  return
end
```

`ws_upgrade_headers_for_origin` sends `Upgrade`, `Connection`, `Sec-WebSocket-Key` and `Sec-WebSocket-Version`, but no `Host`. The four specs that expect `101 Switching Protocols` therefore get `400 Bad Request` on nightly:

- `websocket_allowed_origins allows upgrade when Origin matches allowlist`
- `websocket_allowed_origins normalizes default https port against allowlist`
- `websocket_allowed_origins allows wildcard origin when '*' is in allowlist`
- `websocket_allowed_origins allows missing Origin when '*' is in allowlist`

Specs that expect `403` or `405` are unaffected, because Kemal answers before the request reaches the stdlib handler.

## Change

`Host` joins the baseline handshake headers — a well formed HTTP/1.1 request carries one, and several specs were already setting it by hand. The one spec that asserts Kemal rejects a **missing** Host now deletes it explicitly, which states the intent better than relying on the helper leaving it out.

The other two checks the stdlib added are already satisfied: those specs use `GET`, and `HTTP::Request.new` defaults to `HTTP/1.1`.

`crystal spec` — 348 examples, 0 failures on Crystal 1.21.0. The nightly job on this PR is the real check.